### PR TITLE
Add uninstall action

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ For help, run `battery` without parameters:
 ```
 Battery CLI utility v0.0.2.
 
-Usage: 
+Usage:
 
   battery status
     output battery SMC status, % and time remaining

--- a/README.md
+++ b/README.md
@@ -50,4 +50,8 @@ Usage:
 
   battery update
     run the installation command again to pull latest version
+
+  battery uninstall
+    enable charging and remove the `smc` tool and the `battery` script
+
 ```

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This will:
 For help, run `battery` without parameters:
 
 ```
-Battery CLI utility v0.0.2.
+Battery CLI utility v0.0.4.
 
 Usage:
 

--- a/battery.sh
+++ b/battery.sh
@@ -32,6 +32,9 @@ Usage:
   battery update
     run the installation command again to pull latest version
 
+  battery uninstall
+    enable charging and remove the `smc` tool and the `battery` script
+
 "
 
 # Visudo instructions

--- a/battery.sh
+++ b/battery.sh
@@ -130,6 +130,15 @@ if [[ "$action" == "update" ]]; then
 	exit 0
 fi
 
+# Uninstall helper
+if [[ "$action" == "uninstall" ]]; then
+    echo "This will enable charging, and remove the `smc` tool and `battery` script"
+    echo "Press any key to continue"
+    read
+    enable_charging
+    sudo rm -v "$binfolder/smc" "$binfolder/smc"
+    exit 0
+fi
 
 # Charging on/off controller
 if [[ "$action" == "charging" ]]; then

--- a/battery.sh
+++ b/battery.sh
@@ -11,7 +11,7 @@ visudo_path=/private/etc/sudoers.d/battery
 helpmessage="
 Battery CLI utility v0.0.3.
 
-Usage: 
+Usage:
 
   battery status
     output battery SMC status, % and time remaining
@@ -100,7 +100,7 @@ function log() {
 ## Actions
 ## ###############
 
-# Help message 
+# Help message
 if [ -z "$action" ]; then
 	echo -e "$helpmessage"
 	exit 0
@@ -144,7 +144,7 @@ fi
 if [[ "$action" == "charging" ]]; then
 
 	log "Setting $action to $setting"
-	
+
 	# Set charging to on and off
 	if [[ "$setting" == "on" ]]; then
 		enable_charging
@@ -170,7 +170,7 @@ if [[ "$action" == "charge" ]]; then
 		log "Battery at $battery_percentage%"
 		caffeinate -i sleep 60
 		battery_percentage=$( get_battery_percentage )
-		
+
 	done
 
 	disable_charging
@@ -209,7 +209,7 @@ if [[ "$action" == "maintain" ]]; then
 		sleep 60
 
 		battery_percentage=$( get_battery_percentage )
-		
+
 	done
 
 	exit 0

--- a/battery.sh
+++ b/battery.sh
@@ -9,7 +9,7 @@ visudo_path=/private/etc/sudoers.d/battery
 
 # CLI help message
 helpmessage="
-Battery CLI utility v0.0.3.
+Battery CLI utility v0.0.4.
 
 Usage:
 

--- a/battery.sh
+++ b/battery.sh
@@ -136,7 +136,7 @@ if [[ "$action" == "uninstall" ]]; then
     echo "Press any key to continue"
     read
     enable_charging
-    sudo rm -v "$binfolder/smc" "$binfolder/smc"
+    sudo rm -v "$binfolder/smc" "$binfolder/battery"
     exit 0
 fi
 


### PR DESCRIPTION
Added a simple action to uninstall the `smc` tool and the `battery` script (i.e., partially addressing #1). From what I understand of the `setup.sh` scripts, the steps required to uninstall this utility are:

1. reset battery charging
2. remove `smc` and `battery` from `/usr/local/bin`

I am not entirely sure about (1), but I suppose this boils down to setting the `CH0B` and `CH0C` keys back to `00`? Or is there another way to reset these keys to their corresponding defaults?