### PR TITLE
minor fixes for errors when using the commandline install

### DIFF
--- a/battery.sh
+++ b/battery.sh
@@ -366,3 +366,4 @@ if [[ "$action" == "remove_daemon" ]]; then
 	exit 0
 
 fi
+

--- a/setup.sh
+++ b/setup.sh
@@ -13,7 +13,7 @@ mkdir -p $tempfolder
 
 # Set script value
 calling_user=${1:-"$USER"}
-configfolder=/Users/$calling_usercalling_user/.battery
+configfolder=/Users/$calling_user/.battery
 pidfile=$configfolder/battery.pid
 logfile=$configfolder/battery.log
 


### PR DESCRIPTION
These two changes fix issues when using the commandline install: 

* a typing error resulting in a superfluous `calling_user` messing up the folder structure
* `battery.sh` errored out on ^M lineendings (DOS lineendings)