### PR TITLE
Replace hard-coded value when discharging

### DIFF
--- a/app/modules/battery.js
+++ b/app/modules/battery.js
@@ -172,7 +172,7 @@ const get_battery_status = async () => {
 
         let battery_state = `${ percentage }% (${ remaining } remaining)`
         let daemon_state = ``
-        if( discharging ) daemon_state += `forcing discharge to 80%`
+        if( discharging ) daemon_state += `forcing discharge to ${ maintain_percentage || 80 }%`
         else daemon_state += `smc charging ${ charging ? 'enabled' : 'disabled' }`
 
         return [ battery_state, daemon_state, maintain_percentage ]


### PR DESCRIPTION
When I configured to maintain the battery at 60%, I noticed that the discharge message was hard-coded at 80%. This PR replaces it with the actual value.