### PR TITLE
Remove the regularly appearing notification 'Background Items Added' (introduced in macOS 13 Ventura)

### DIFF
--- a/battery.sh
+++ b/battery.sh
@@ -4,7 +4,7 @@
 ## Update management
 ## variables are used by this binary as well at the update script
 ## ###############
-BATTERY_CLI_VERSION="v1.0.2"
+BATTERY_CLI_VERSION="v1.0.3"
 
 # Path fixes for unexpected environments
 PATH=/bin:/usr/bin:/usr/local/bin:/usr/sbin:/opt/homebrew

--- a/battery.sh
+++ b/battery.sh
@@ -487,7 +487,17 @@ if [[ "$action" == "create_daemon" ]]; then
 "
 
 	mkdir -p "${daemon_path%/*}"
-	echo "$daemon_definition" > "$daemon_path"
+	# check if daemon already exists
+	if test -f "$daemon_path"; then
+		daemon_definition_difference=$(diff --brief --ignore-space-change --strip-trailing-cr --ignore-blank-lines  <( cat "$daemon_path" 2> /dev/null ) <(echo "$daemon_definition"))
+		if [[ "$daemon_definition_difference" != "" ]]; then
+			# daemon_definition changed: replace with new definitions
+			echo "$daemon_definition" > "$daemon_path"
+		fi
+	else
+		# daemon not available, create new launch deamon
+		echo "$daemon_definition" > "$daemon_path"
+	fi
 
 	exit 0
 

--- a/battery.sh
+++ b/battery.sh
@@ -490,6 +490,7 @@ if [[ "$action" == "create_daemon" ]]; then
 	# check if daemon already exists
 	if test -f "$daemon_path"; then
 		daemon_definition_difference=$(diff --brief --ignore-space-change --strip-trailing-cr --ignore-blank-lines  <( cat "$daemon_path" 2> /dev/null ) <(echo "$daemon_definition"))
+		# remove leading and trailing whitespaces
 		daemon_definition_difference=$(echo "$daemon_definition_difference" | xargs)
 		if [[ "$daemon_definition_difference" != "" ]]; then
 			# daemon_definition changed: replace with new definitions
@@ -507,6 +508,7 @@ fi
 
 # Disable daemon
 if [[ "$action" == "disable_daemon" ]]; then
+
 	launchctl disable "gui/$(id -u $USER)/com.battery.app"
 	exit 0
 
@@ -514,6 +516,7 @@ fi
 
 # Remove daemon
 if [[ "$action" == "remove_daemon" ]]; then
+
 	rm $daemon_path 2> /dev/null
 	exit 0
 

--- a/battery.sh
+++ b/battery.sh
@@ -407,7 +407,7 @@ if [[ "$action" == "maintain" ]]; then
 		log "Killing running maintain daemons & enabling charging as default state"
 		rm $pidfile 2> /dev/null
 		rm $maintain_percentage_tracker_file 2> /dev/null
-		battery remove_daemon
+		battery disable_daemon
 		enable_charging
 		battery status
 		exit 0
@@ -490,6 +490,7 @@ if [[ "$action" == "create_daemon" ]]; then
 	# check if daemon already exists
 	if test -f "$daemon_path"; then
 		daemon_definition_difference=$(diff --brief --ignore-space-change --strip-trailing-cr --ignore-blank-lines  <( cat "$daemon_path" 2> /dev/null ) <(echo "$daemon_definition"))
+		daemon_definition_difference=$(echo "$daemon_definition_difference" | xargs)
 		if [[ "$daemon_definition_difference" != "" ]]; then
 			# daemon_definition changed: replace with new definitions
 			echo "$daemon_definition" > "$daemon_path"
@@ -498,14 +499,21 @@ if [[ "$action" == "create_daemon" ]]; then
 		# daemon not available, create new launch deamon
 		echo "$daemon_definition" > "$daemon_path"
 	fi
+	# enable daemon
+	launchctl enable "gui/$(id -u $USER)/com.battery.app"
+	exit 0
 
+fi
+
+# Disable daemon
+if [[ "$action" == "disable_daemon" ]]; then
+	launchctl disable "gui/$(id -u $USER)/com.battery.app"
 	exit 0
 
 fi
 
 # Remove daemon
 if [[ "$action" == "remove_daemon" ]]; then
-
 	rm $daemon_path 2> /dev/null
 	exit 0
 


### PR DESCRIPTION
The proposed change modifies the "create_daemon" function, so that the daemon file is only overwritten if it does not yet exist or the contents have changed. 

This fixes the frequently appearing notification 'Background Items Added' (introduced in macOS 13 Ventura)

This notification occurs, for instance, when the app is restarted or when "battery maintain 80" is executed. 