### PR TITLE
Correct way to determine battery percentage icon for the menu tray

### DIFF
--- a/app/modules/theme.js
+++ b/app/modules/theme.js
@@ -23,7 +23,7 @@ const get_logo_template = ( percent = 100, active ) => {
     for( let percentage = 0; percentage <= 100; percentage+=percentage_increment_to_render ) {
         image_percentages.push( percentage )
     }
-    image_percentages.sort()
+    image_percentages.sort((a, b) => a - b)
 
     // Find which image size is the highest that is still under the current percentage
     let display_percentage = 20

--- a/app/modules/theme.js
+++ b/app/modules/theme.js
@@ -26,11 +26,8 @@ const get_logo_template = ( percent = 100, active ) => {
     image_percentages.sort((a, b) => a - b)
 
     // Find which image size is the highest that is still under the current percentage
-    let display_percentage = 20
-    image_percentages.map( percent_option => {
-        if( percent_option <= percent ) display_percentage = percent_option
-    } )
-    log( `Display percentage ${ display_percentage } based on ${ percent }` )
+    let display_percentage = image_percentages.findLast((p) => p < percent)
+    log(`Display percentage ${display_percentage} based on ${percent}`)
 
     const image_path = path.join( asset_path, `/battery-${ active ? 'active' : 'inactive' }-${ display_percentage }-Template.png` )
     const exists = existsSync( image_path )


### PR DESCRIPTION
As mentioned in #105 the way the battery percentage for the menu tray icon is computed is not correct, the issue mentions `Display percentage 5 based on 46`. The reason for this is that in https://github.com/actuallymentor/battery/blob/848ee9ba175b92e6a75acac8d60e9a956bc7a88f/app/modules/theme.js#L26 the sort is lexicographical resulting in `[0, 10, 100, 15, 20, 25, 30, 35, 40, 45, 5, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95]`

This PR fixes #105 using the correct sort and also simplifying the way the percentage is  fetched from the sorted array.