### PR TITLE
Battery percentage calculated

### DIFF
--- a/app/modules/theme.js
+++ b/app/modules/theme.js
@@ -19,15 +19,8 @@ const get_logo_template = ( percent = 100, active ) => {
     // Image sizes available
     // see assets/modules/compile-images.je for values
     const percentage_increment_to_render = 5
-    const image_percentages = []
-    for( let percentage = 0; percentage <= 100; percentage+=percentage_increment_to_render ) {
-        image_percentages.push( percentage )
-    }
-    image_percentages.sort((a, b) => a - b)
-
-    // Find which image size is the highest that is still under the current percentage
-    let display_percentage = image_percentages.findLast((p) => p < percent)
-    log(`Display percentage ${display_percentage} based on ${percent}`)
+    const display_percentage = Math.floor( percent / percentage_increment_to_render ) * percentage_increment_to_render
+    log( `Display percentage ${ display_percentage } based on ${ percent }` )
 
     const image_path = path.join( asset_path, `/battery-${ active ? 'active' : 'inactive' }-${ display_percentage }-Template.png` )
     const exists = existsSync( image_path )

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "battery",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "A battery charge limiter for Apple silicon Mac devices",
   "main": "main.js",
   "build": {


### PR DESCRIPTION
A small refactor of the way the battery percentage icon is selected.
Using `Math.floor` to calculate the "rounded" value.

@igorkulman Inspired by PR #119

Mini test:

```
Display percentage 0 based on 0
Display percentage 0 based on 1
Display percentage 0 based on 4
Display percentage 5 based on 5
Display percentage 5 based on 6
Display percentage 45 based on 49
Display percentage 50 based on 50
Display percentage 50 based on 51
Display percentage 95 based on 99
Display percentage 100 based on 100
```