### PR TITLE
Fix for issue #129, #73, #107, etc 

### DIFF
--- a/battery.sh
+++ b/battery.sh
@@ -352,6 +352,8 @@ if [[ "$action" == "maintain_synchronous" ]]; then
 		if [[ $maintain_percentage ]]; then
 			log "Recovering maintenance percentage $maintain_percentage"
 			setting=$( echo $maintain_percentage)
+			battery maintain $setting
+			read 
 		else
 			log "No setting to recover, exiting"
 			exit 0
@@ -531,7 +533,6 @@ fi
 
 # Disable daemon
 if [[ "$action" == "disable_daemon" ]]; then
-
 	log "Disabling daemon at gui/$(id -u $USER)/com.battery.app"
 	launchctl disable "gui/$(id -u $USER)/com.battery.app"
 	exit 0
@@ -540,7 +541,6 @@ fi
 
 # Remove daemon
 if [[ "$action" == "remove_daemon" ]]; then
-
 	rm $daemon_path 2> /dev/null
 	exit 0
 


### PR DESCRIPTION
This pr fixes the issue that multiple users have reported regarding changing to a new battery maintain value not working as intended. ( #129, #73, #107 etc)
The bug occurred because `battery recover` started with launchctl would run indefinitely with the `maintain.percentage` value it started up with, and new instances of `battery maintain n` would not kill the process like it would for other processes started with `battery maintain n`. 
This fix makes it so that `battery recover` behaves with the same process finding & killing logic as `battery maintain` does, thus fixing the issue. 

To fix later; this fix still has the problem that the startup daemon doesn't get killed unless manually done so by the user with `launchctl stop com.battery.app` etc. This behavior _can_ be changed so no useless background processes are there using up (small amounts of) memory but I decided implementing the change would change the code structure too much. Maybe @actuallymentor can do that later. 