### PR TITLE
CLI GUI compatibility

### DIFF
--- a/battery.sh
+++ b/battery.sh
@@ -417,7 +417,6 @@ if [[ "$action" == "maintain" ]]; then
 	if [[ "$setting" == "stop" ]]; then
 		log "Killing running maintain daemons & enabling charging as default state"
 		rm $pidfile 2> /dev/null
-		rm $maintain_percentage_tracker_file 2> /dev/null
 		battery disable_daemon
 		enable_charging
 		battery status

--- a/battery.sh
+++ b/battery.sh
@@ -248,7 +248,8 @@ if [[ "$action" == "uninstall" ]]; then
     enable_charging
 	disable_discharging
 	battery remove_daemon
-    sudo rm -v "$binfolder/smc" "$binfolder/battery"
+    sudo rm -v "$binfolder/smc" "$binfolder/battery" 
+	sudo rm -v -r "$configfolder"
 	pkill -f "/usr/local/bin/battery.*"
     exit 0
 fi


### PR DESCRIPTION
Fix for issue #149 and #128: The percentage set in the CLI is not persistent upon GUI reboot, and reset to 80%. 

**Problem**: On launch of the GUI, the maintain.percentage file is deleted, causing the GUI to recreate the file with default value of 80.
this is caused by the call "battery maintain stop" which deletes the maintain.percentage file. 

This issue is easily reproduced by changing the `battery maintain 70` via CLI, and then launching the GUI. 
 
**Solution**: Remove the deletion of file maintain.percentage in "battery maintain stop" to keep persistence of any previous setting.
-> I have added the deletion of all config files upon uninstall so default settings are back if the user reinstalls battery. 

**Test**: The solution was tested by changing the value through the CLI, and rebooting the GUI multiple times. + Uninstalling the CLI removes the `.battery` file. 

Closes #149, Closes #128 