### PR TITLE
Update MagSafe LED if threshold reached when AC charger is connected

### DIFF
--- a/battery.sh
+++ b/battery.sh
@@ -204,6 +204,11 @@ function get_remaining_time() {
 	echo "$time_remaining"
 }
 
+function get_charger_state() {
+	ac_attached=$(pmset -g batt | tail -n1 | awk '{ x=match($0, /AC attached/) > 0; print x }')
+	echo "$ac_attached"
+}
+
 function get_maintain_percentage() {
 	maintain_percentage=$(cat $maintain_percentage_tracker_file 2>/dev/null)
 	echo "$maintain_percentage"
@@ -443,8 +448,9 @@ if [[ "$action" == "maintain_synchronous" ]]; then
 
 		# Keep track of status
 		is_charging=$(get_smc_charging_status)
+		ac_attached=$(get_charger_state)
 
-		if [[ "$battery_percentage" -ge "$setting" && "$is_charging" == "enabled" ]]; then
+		if [[ "$battery_percentage" -ge "$setting" && ( "$is_charging" == "enabled" || "$ac_attached" == "1" ) ]]; then
 
 			log "Charge above $setting"
 			disable_charging

--- a/battery.sh
+++ b/battery.sh
@@ -453,7 +453,9 @@ if [[ "$action" == "maintain_synchronous" ]]; then
 		if [[ "$battery_percentage" -ge "$setting" && ( "$is_charging" == "enabled" || "$ac_attached" == "1" ) ]]; then
 
 			log "Charge above $setting"
-			disable_charging
+			if [[ "$is_charging" == "enabled" ]]; then
+				disable_charging
+			fi
 			change_magsafe_led_color "green"
 
 		elif [[ "$battery_percentage" -lt "$setting" && "$is_charging" == "disabled" ]]; then


### PR DESCRIPTION
If the charge is above the threshold when the AC charger is connected (i.e the charger was attached when the battery was above e.g. 80%), turn the MagSafe LED green on the next iteration.