### PR TITLE
fix adapter action

### DIFF
--- a/battery.sh
+++ b/battery.sh
@@ -343,9 +343,9 @@ if [[ "$action" == "adapter" ]]; then
 
 	# Set charging to on and off
 	if [[ "$setting" == "on" ]]; then
-		enable_discharging
-	elif [[ "$setting" == "off" ]]; then
 		disable_discharging
+	elif [[ "$setting" == "off" ]]; then
+		enable_discharging
 	fi
 
 	exit 0


### PR DESCRIPTION
Current `battery adapter on/off` is enabling adapter when action is `off` and disabling adapter when action is `on`. This should work viceversa 