### PR TITLE
Voltage limit

### DIFF
--- a/battery.sh
+++ b/battery.sh
@@ -229,7 +229,7 @@ function get_maintain_percentage() {
 }
 
 function get_voltage() {
-	voltage=$(ioreg -l -n AppleSmartBattery -r | grep "\"Voltage\" =" | awk '{ print $3/1000 }')
+	voltage=$(ioreg -l -n AppleSmartBattery -r | grep "\"Voltage\" =" | awk '{ print $3/1000 }' | tr ',' '.')
 	echo "$voltage"
 }
 

--- a/battery.sh
+++ b/battery.sh
@@ -446,10 +446,10 @@ if [[ "$action" == "voltage" ]]; then
 
 		log "Battery at ${voltage}V"
 		
-		if (( $(echo "$voltage < $setting" | bc -l) && "$is_charging" == "disabled" )); then
+		if (( $(echo "$voltage < $setting" | bc -l) )) && [[ "$is_charging" == "disabled" ]]; then
 			enable_charging
 		fi
-		if (( $(echo "$voltage >= $subsetting" | bc -l) && "$is_charging" == "enabled" )); then
+		if (( $(echo "$voltage >= $subsetting" | bc -l) )) && [[ "$is_charging" == "enabled" ]]; then
 			disable_charging
 		fi
 		

--- a/battery.sh
+++ b/battery.sh
@@ -612,8 +612,6 @@ if [[ "$action" == "maintain" ]]; then
 
 	fi
 
-	exit 1
-
 	# Start maintenance script
 	if [ "$is_voltage" = true ]; then
 	  log "Starting battery maintenance at ${setting}V ±${subsetting}V"


### PR DESCRIPTION
This is a draft for the feature request in #214.

Output:
```
./battery.sh voltage 11.55 11.7 
01/17/24-19:47:18 - Keeping voltage between 11.55V and 11.7V
01/17/24-19:47:18 - Battery at 11.55V
01/17/24-19:48:18 - Battery at 11.551V
01/17/24-19:49:18 - Battery at 11.549V
01/17/24-19:49:18 - 🔌🔋 Enabling battery charging
01/17/24-19:49:18 - 🔼🪫 Disabling battery discharging
01/17/24-19:50:18 - Battery at 11.688V
01/17/24-19:51:19 - Battery at 11.704V
01/17/24-19:51:19 - 🔌🪫 Disabling battery charging
01/17/24-19:52:19 - Battery at 11.587V
01/17/24-19:53:19 - Battery at 11.569V
01/17/24-19:54:19 - Battery at 11.566V
```