### PR TITLE
feature: maintain battery in a certain range

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Example usage:
 ```shell
 # This will enable charging when your battery dips under 80, and disable it when it exceeds 80
 battery maintain 80
+# This will enable charging when your battery dips under 30, and disable it when it exceeds 70
+battery maintain 30-70
 ```
 
 After running a command like `battery charging off` you can verify the change visually by looking at the battery icon:
@@ -69,17 +71,23 @@ After running `battery charging on` you will see it change to this:
 For help, run `battery` without parameters:
 
 ```
-Battery CLI utility v1.0.1
+Battery CLI utility v1.2.0
 
 Usage:
 
   battery status
     output battery SMC status, % and time remaining
 
-  battery maintain LEVEL[1-100,stop]
-    reboot-persistent battery level maintenance: turn off charging above, and on below a certain value
-    eg: battery maintain 80
-    eg: battery maintain stop
+  battery maintain LEVEL[value/minvalue-maxvalue/stop]
+    reboot-persistent battery level maintenance. There are two modes:
+      threshold mode:
+        turn off charging above, and on below a certain value.
+      range mode:
+        turn off charging above the maximum value, and on below the minimum value.
+    it has the option of a --force-discharge flag that discharges even when plugged in (this does NOT work well with clamshell mode)
+    eg: battery maintain 80           // threshold mode
+    eg: battery maintain 20-80        // range mode
+    eg: battery maintain stop         // disable maintain mode
 
   battery charging SETTING[on/off]
     manually set the battery to (not) charge

--- a/battery.sh
+++ b/battery.sh
@@ -4,7 +4,7 @@
 ## Update management
 ## variables are used by this binary as well at the update script
 ## ###############
-BATTERY_CLI_VERSION="v1.1.6"
+BATTERY_CLI_VERSION="v1.2.0"
 
 # Path fixes for unexpected environments
 PATH=/bin:/usr/bin:/usr/local/bin:/usr/sbin:/opt/homebrew/bin:/opt/homebrew/sbin:/opt/homebrew

--- a/battery.sh
+++ b/battery.sh
@@ -500,20 +500,23 @@ if [[ "$action" == "maintain" ]]; then
 		exit 0
 	fi
 
-	if [[ "$setting" =~ ^[0-9]{1,3}-[0-9]{1,3}$ ]];then
+	# Check if setting is range mode
+	if [[ "$setting" =~ ^[0-9]+-[0-9]+$ ]];then
+		log "Called with range $setting $action"
 		IFS=- read lower_threshold upper_threshold <<<"$setting"
-		if [ "$lower_threshold" -lt 0 ] || [ "$lower_threshold" -gt 100 ] ||
-			[ "$upper_threshold" -lt 0 ] || [ "$upper_threshold" -gt 100 ] ||
+		if [ "$lower_threshold" -lt 1 ] || [ "$lower_threshold" -gt 100 ] ||
+			[ "$upper_threshold" -lt 1 ] || [ "$upper_threshold" -gt 100 ] ||
 			[ "$lower_threshold" -gt "$upper_threshold" ];then
-			log "Error: $setting is not a valid range setting for battery maintain. The min/max value should between 0 and 100. A range example like 30-80"
+			log "Error: $setting is not a valid range setting for battery maintain. The min/max value should between 1 and 100. A range example like 30-80"
+			exit 1
 		fi
-	# Check if setting is value between 0 and 100
-	elif ! [[ "$setting" =~ ^[0-9]+$ ]] || [[ "$setting" -lt 0 ]] || [[ "$setting" -gt 100 ]]; then
+	# Check if setting is value between 1 and 100
+	elif ! [[ "$setting" =~ ^[0-9]+$ ]] || [[ "$setting" -lt 1 ]] || [[ "$setting" -gt 100 ]]; then
 
 		log "Called with $setting $action"
 		# If non 0-100 setting is not a special keyword, exit with an error.
 		if ! { [[ "$setting" == "stop" ]] || [[ "$setting" == "recover" ]]; }; then
-			log "Error: $setting is not a valid setting for battery maintain. Please use a number between 0 and 100, or an action keyword like 'stop' or 'recover'."
+			log "Error: $setting is not a valid setting for battery maintain. Please use a number between 1 and 100, or an action keyword like 'stop' or 'recover'."
 			exit 1
 		fi
 

--- a/battery.sh
+++ b/battery.sh
@@ -52,15 +52,15 @@ Usage:
 	eg: battery logs 100
 
   battery maintain LEVEL[value/minvalue-maxvalue/stop]
-  reboot-persistent battery level maintenance:
-      Threshold mode:
+    reboot-persistent battery level maintenance. There are two modes:
+      threshold mode:
         turn off charging above, and on below a certain value.
-      Range mode:
+      range mode:
         turn off charging above the maximum value, and on below the minimum value.
     it has the option of a --force-discharge flag that discharges even when plugged in (this does NOT work well with clamshell mode)
-    eg: battery maintain 80           // Threshold mode
-    eg: battery maintain 20-80        // Range mode
-    eg: battery maintain stop
+    eg: battery maintain 80           // threshold mode
+    eg: battery maintain 20-80        // range mode
+    eg: battery maintain stop         // disable maintain mode
 
   battery charging SETTING[on/off]
     manually set the battery to (not) charge
@@ -441,14 +441,14 @@ if [[ "$action" == "maintain_synchronous" ]]; then
 	# Start charging
 	battery_percentage=$(get_battery_percentage)
 
-  IFS=- read lower_threshold upper_threshold <<<"$setting"
-  if [ -z "$upper_threshold" ];then
-    upper_threshold=$lower_threshold
-  fi
-  if [ "$lower_threshold" -eq "$upper_threshold" ];then
-	  log "Charging to and maintaining at $lower_threshold% from $battery_percentage%"
-  else
-	  log "Charging to and maintaining in range of $lower_threshold% to $upper_threshold% from $battery_percentage%"
+	IFS=- read lower_threshold upper_threshold <<<"$setting"
+	if [ -z "$upper_threshold" ];then
+		upper_threshold=$lower_threshold
+	fi
+	if [ "$lower_threshold" -eq "$upper_threshold" ];then
+		log "Charging to and maintaining at $lower_threshold% from $battery_percentage%"
+	else
+		log "Charging to and maintaining in range of $lower_threshold% to $upper_threshold% from $battery_percentage%"
 	fi
 
 	# Loop until battery percent is exceeded
@@ -500,13 +500,13 @@ if [[ "$action" == "maintain" ]]; then
 		exit 0
 	fi
 
-  if [[ "$setting" =~ ^[0-9]{1,3}-[0-9]{1,3}$ ]];then
-    IFS=- read lower_threshold upper_threshold <<<"$setting"
-    if [ "$lower_threshold" -lt 0 ] || [ "$lower_threshold" -gt 100 ] ||
-      [ "$upper_threshold" -lt 0 ] || [ "$upper_threshold" -gt 100 ] ||
-      [ "$lower_threshold" -gt "$upper_threshold" ];then
-			log "Error: $setting is not a valid range setting for battery maintain. Please use a range just like 30-80, or an action keyword like 'stop' or 'recover'."
-    fi
+	if [[ "$setting" =~ ^[0-9]{1,3}-[0-9]{1,3}$ ]];then
+		IFS=- read lower_threshold upper_threshold <<<"$setting"
+		if [ "$lower_threshold" -lt 0 ] || [ "$lower_threshold" -gt 100 ] ||
+			[ "$upper_threshold" -lt 0 ] || [ "$upper_threshold" -gt 100 ] ||
+			[ "$lower_threshold" -gt "$upper_threshold" ];then
+			log "Error: $setting is not a valid range setting for battery maintain. The min/max value should between 0 and 100. A range example like 30-80"
+		fi
 	# Check if setting is value between 0 and 100
 	elif ! [[ "$setting" =~ ^[0-9]+$ ]] || [[ "$setting" -lt 0 ]] || [[ "$setting" -gt 100 ]]; then
 

--- a/battery.sh
+++ b/battery.sh
@@ -51,17 +51,16 @@ Usage:
     output logs of the battery CLI and GUI
 	eg: battery logs 100
 
-  battery maintain LEVEL[1-100,stop]
-  battery maintain RANGE[min-max]
-    reboot-persistent battery level maintenance:
-      Threshold Mode:
+  battery maintain LEVEL[value/minvalue-maxvalue/stop]
+  reboot-persistent battery level maintenance:
+      Threshold mode:
         turn off charging above, and on below a certain value.
-      Range Mode:
+      Range mode:
         turn off charging above the maximum value, and on below the minimum value.
     it has the option of a --force-discharge flag that discharges even when plugged in (this does NOT work well with clamshell mode)
-    eg: battery maintain 80
+    eg: battery maintain 80           // Threshold mode
+    eg: battery maintain 20-80        // Range mode
     eg: battery maintain stop
-    eg: battery maintain 20-70
 
   battery charging SETTING[on/off]
     manually set the battery to (not) charge


### PR DESCRIPTION
Allow battery tool to maintain battery between in a certain range.
Syntax: battery maintain min-max
Battery tool turn off charging above the maximum value, and on below the minimum value.
eg: battery maintain 20-70
eg: battery maintain 30-30
