### PR TITLE
Fix for #104: added integer check for charge command argument

### DIFF
--- a/battery.sh
+++ b/battery.sh
@@ -357,7 +357,7 @@ if [[ "$action" == "charge" ]]; then
 
 	# Check if percentage is an integer [1-100]
 	if ! [[ $setting =~ ^[1-9][0-9]?$|^100$ ]]; then
-		log "Battery percentage is not a valid percentage [1-100], exiting (battery percentage: $setting)"
+		log "Specified percentage ($setting) is not valid. Please specify an integer [1-100]."
 		exit 1
 	fi
 

--- a/battery.sh
+++ b/battery.sh
@@ -357,7 +357,7 @@ if [[ "$action" == "charge" ]]; then
 
 	# Check if percentage is an integer [1-100]
 	if ! [[ $setting =~ ^[1-9][0-9]?$|^100$ ]]; then
-		log "Battery percentage is not a valid number, exiting (battery percentage: $setting)"
+		log "Battery percentage is not a valid percentage [1-100], exiting (battery percentage: $setting)"
 		exit 1
 	fi
 

--- a/battery.sh
+++ b/battery.sh
@@ -355,6 +355,12 @@ fi
 # Charging on/off controller
 if [[ "$action" == "charge" ]]; then
 
+	# Check if percentage is an integer [1-100]
+	if ! [[ $setting =~ ^[1-9][0-9]?$|^100$ ]]; then
+		log "Battery percentage is not a valid number, exiting (battery percentage: $setting)"
+		exit 1
+	fi
+
 	# Disable running daemon
 	battery maintain stop
 


### PR DESCRIPTION
Fix for #104. Check the argument of the charge command to be a number between 1 and 100.

<img width="682" alt="image" src="https://github.com/actuallymentor/battery/assets/22987218/90095eb4-23df-48a7-8d38-654f45689efe">

