### PR TITLE
Improve accuracy when stopping charging

### DIFF
--- a/battery.sh
+++ b/battery.sh
@@ -487,7 +487,6 @@ if [[ "$action" == "maintain_synchronous" ]]; then
 				sleep 60
 
 			fi
-		fi
 
 		battery_percentage=$(get_battery_percentage)
 

--- a/battery.sh
+++ b/battery.sh
@@ -442,23 +442,27 @@ if [[ "$action" == "maintain_synchronous" ]]; then
 	while true; do
 
 		# Keep track of status
-		is_charging=$(get_smc_charging_status)
+		if [[ "$battery_percentage" -ge "$((setting - 3))" && "$battery_percentage" -lt "$setting" && "$is_charging" == "enabled" ]]; then
+				sleep 20
 
-		if [[ "$battery_percentage" -ge "$setting" && "$is_charging" == "enabled" ]]; then
+			else
 
-			log "Charge above $setting"
-			disable_charging
-			change_magsafe_led_color "green"
+				if [[ "$battery_percentage" -ge "$setting" && "$is_charging" == "enabled" ]]; then
+					log "Charge above $setting"
+					disable_charging
+					change_magsafe_led_color "green"
 
-		elif [[ "$battery_percentage" -lt "$setting" && "$is_charging" == "disabled" ]]; then
+				elif [[ "$battery_percentage" -lt "$setting" && "$is_charging" == "disabled" ]]; then
+					log "Charge below $setting"
+					enable_charging
+					change_magsafe_led_color "orange"
 
-			log "Charge below $setting"
-			enable_charging
-			change_magsafe_led_color "orange"
+				fi
 
+				sleep 60
+
+			fi
 		fi
-
-		sleep 60
 
 		battery_percentage=$(get_battery_percentage)
 


### PR DESCRIPTION
I've noticed that because the script only runs every 60 seconds, and my computer usually does more than 
a 1% increase in that time, I'll often end up 1-2% over the limit. 

To fix this, this PR sleeps the script for 20 instead of 60 within 3% of the target.