### PR TITLE
Reorder paths.

### DIFF
--- a/app/modules/battery.js
+++ b/app/modules/battery.js
@@ -4,7 +4,7 @@ const { exec } = require( 'node:child_process' )
 const { log, alert, wait, confirm } = require( './helpers' )
 const { get_force_discharge_setting } = require( './settings' )
 const { USER } = process.env
-const path_fix = 'PATH=/bin:/usr/bin:/usr/local/bin:/usr/sbin:/opt/homebrew/bin:/opt/homebrew/sbin:/opt/homebrew'
+const path_fix = 'PATH=/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin'
 const battery = `${ path_fix } battery`
 const shell_options = {
     shell: '/bin/bash',

--- a/battery.sh
+++ b/battery.sh
@@ -7,7 +7,7 @@
 BATTERY_CLI_VERSION="v1.1.6"
 
 # Path fixes for unexpected environments
-PATH=/bin:/usr/bin:/usr/local/bin:/usr/sbin:/opt/homebrew/bin:/opt/homebrew/sbin:/opt/homebrew
+PATH=/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
 
 ## ###############
 ## Variables


### PR DESCRIPTION
It's important to order the paths from the most specific to the most general.

This fixes the issue where binaries installed via Homebrew were ignored.

Also, removed `/opt/homebrew` from the list of paths. Homebrew does not install programs to its root directory.
