### PR TITLE
README installation clarification for homebrew users expecting `brew install` to finish CLI installation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,19 +1,17 @@
 {
-	"i18n-ally.localesPaths": [
-		"public/locales"
-	],
-	"i18n-ally.keystyle": "nested",
-	"eslint.validate": [
-		"javascript",
-		"javascriptreact",
-		"typescript",
-		"typescriptreact"
-	],
-	"editor.codeActionsOnSave": {
-		"source.fixAll.eslint": true
-	},
-	"editor.renderWhitespace": "all",
-	"editor.formatOnSave": true,
-	"eslint.format.enable": true,
-	"eslint.run": "onType"
+  "i18n-ally.localesPaths": ["public/locales"],
+  "i18n-ally.keystyle": "nested",
+  "eslint.validate": [
+    "javascript",
+    "javascriptreact",
+    "typescript",
+    "typescriptreact"
+  ],
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit"
+  },
+  "editor.renderWhitespace": "all",
+  "editor.formatOnSave": true,
+  "eslint.format.enable": true,
+  "eslint.run": "onType"
 }

--- a/README.md
+++ b/README.md
@@ -10,9 +10,11 @@ This is an app for Apple Silicon Macs. It will not work on Intel macs. Do you ha
 
 ### Installation
 
-- Option 1: install through brew with `brew install battery`
-- Option 2: [You can download the latest app dmg version here](https://github.com/actuallymentor/battery/releases/).
+- Option 1: install the app through brew with `brew install battery`
+- Option 2: [download the latest app dmg version here](https://github.com/actuallymentor/battery/releases/)
 - Option 3: command-line only installation (see section below)
+
+When installing via brew or dmg, opening the macOS app is required to complete the installation.
 
 The first time you open the app, it will ask for your administator password so it can install the needed components. Please note that the app:
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ This is an app for Apple Silicon Macs. It will not work on Intel macs. Do you ha
 ### Installation
 
 - Option 1: install the app through brew with `brew install battery`
-- Option 2: [download the latest app dmg version here](https://github.com/actuallymentor/battery/releases/)
-- Option 3: command-line only installation (see section below)
+- Option 2: [download the app dmg version here](https://github.com/actuallymentor/battery/releases/)
+- Option 3: install ONLY the command line interface (see section below)
 
 When installing via brew or dmg, opening the macOS app is required to complete the installation.
 


### PR DESCRIPTION
Clarify in the README that `brew install battery` does not alone completely install the command line tools.

I expected brew to complete the installation of the command line tools. I couldn't locate the tools anywhere. The README didn't explain clearly that `brew install` creates a macOS app that must be run to complete the command line installation.

I expect many others familiar with typical projects manageable with homebrew to have the same confusion. I made very small edits on two lines in the README to address the confusion.

The homebrew cask could separately be updated to be clearer that it's not just the CLI and that the app needs to be run.

I also fixed a small vscode setting for eslint that has been deprecated since vscode 1.85 (November 2023).
