### PR TITLE
🐛 first check for recover setting, then valid_percentage

### DIFF
--- a/battery.sh
+++ b/battery.sh
@@ -518,11 +518,6 @@ if [[ "$action" == "maintain_synchronous" ]]; then
 		log "🚨 Calibration process have been stopped"
 	fi
 
-	if ! valid_percentage "$setting"; then
-		log "Error: $setting is not a valid setting for battery maintain. Please use a number between 0 and 100"
-		exit 1
-	fi
-
 	# Recover old maintain status if old setting is found
 	if [[ "$setting" == "recover" ]]; then
 
@@ -537,6 +532,11 @@ if [[ "$action" == "maintain_synchronous" ]]; then
 			log "No setting to recover, exiting"
 			exit 0
 		fi
+	fi
+
+	if ! valid_percentage "$setting"; then
+		log "Error: $setting is not a valid setting for battery maintain. Please use a number between 0 and 100"
+		exit 1
 	fi
 
 	# Check if the user requested that the battery maintenance first discharge to the desired level

--- a/battery.sh
+++ b/battery.sh
@@ -4,7 +4,7 @@
 ## Update management
 ## variables are used by this binary as well at the update script
 ## ###############
-BATTERY_CLI_VERSION="v1.2.6"
+BATTERY_CLI_VERSION="v1.2.7"
 
 # Path fixes for unexpected environments
 PATH=/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin


### PR DESCRIPTION
**Problem**
`battery maintain_synchronous recover` should launch at login per `~/Library/LaunchAgents/battery.plist`. It fails, however, with the message in logs: _Error: recover is not a valid setting for battery maintain. Please use a number between 0 and 100_. As a result, the policy is not enforced and requires `battery maintain 80` to be entered manually.

**Solution**
Reorder `valid_percentage` and `recover` clauses.

**Evidence**
Before the fix:
```
alex@alex-mbp ~ % battery maintain_synchronous recover
07/08/24-11:59:21 - Error: recover is not a valid setting for battery maintain. Please use a number between 0 and 100
```

With the fix:
```
alex@alex-mbp ~ % battery maintain_synchronous recover
07/08/24-12:03:29 - Debug trail. User: alex, config folder: /Users/alex/.battery, logfile: /Users/alex/.battery/battery.log, file called with 1: maintain_synchronous, 2: recover
07/08/24-12:03:29 - Recovering maintenance percentage 80
07/08/24-12:03:29 - Not triggering discharge as it is not requested
07/08/24-12:03:29 - Charging to and maintaining at 80% from 82%
```