### PR TITLE
Adding information in the commandline tool help to prevent accidental `discharge` during clamshell mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Usage:
 
   battery discharge LEVEL[1-100]
     block power input from the adapter until battery falls to this level
+    should not be used when your laptop is used in clamshell mode
     eg: battery discharge 90
 
   battery visudo

--- a/battery.sh
+++ b/battery.sh
@@ -88,6 +88,7 @@ Usage:
 
   battery discharge LEVEL[1-100]
     block power input from the adapter until battery falls to this level
+    should not be used when your laptop is used in clamshell mode
     eg: battery discharge 90
 
   battery visudo


### PR DESCRIPTION
`battery discharge` should not be used with clamshell mode. (Laptop just goes to sleep) These two commits add information to the `battery` commandline tool output and the `README.md` that also prints the output of the `battery` commandline tool that warns against using `battery discharge` while in clamshell mode.