### PR TITLE
Support putting config dir in $XDG_CONFIG_HOME

### DIFF
--- a/app/modules/helpers.js
+++ b/app/modules/helpers.js
@@ -1,5 +1,5 @@
 const { promises: fs } = require( 'fs' )
-const { HOME } = process.env
+const { HOME, XDG_CONFIG_HOME } = process.env
 let has_alerted_user_no_home = false
 
 const { dialog } = require( 'electron' )
@@ -19,7 +19,10 @@ const log = async ( ...messages ) => {
 
     // Log to file if possible
     try {
-        if( HOME ) {
+        if( XDG_CONFIG_HOME ) {
+            await fs.mkdir( `${ XDG_CONFIG_HOME }/battery/`, { recursive: true } )
+            await fs.appendFile( `${ XDG_CONFIG_HOME }/battery/gui.log`, `${ messages.join( '\n' ) }\n`, 'utf8' )
+        } else if( HOME ) {
             await fs.mkdir( `${ HOME }/.battery/`, { recursive: true } )
             await fs.appendFile( `${ HOME }/.battery/gui.log`, `${ messages.join( '\n' ) }\n`, 'utf8' )
         } else if( !has_alerted_user_no_home ) {

--- a/battery.sh
+++ b/battery.sh
@@ -15,7 +15,7 @@ PATH=/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin
 binfolder=/usr/local/bin
 visudo_folder=/private/etc/sudoers.d
 visudo_file=${visudo_folder}/battery
-configfolder=$HOME/.battery
+[ -n "$XDG_CONFIG_HOME" ] && configfolder=$XDG_CONFIG_HOME/battery || configfolder=$HOME/.battery
 pidfile=$configfolder/battery.pid
 logfile=$configfolder/battery.log
 maintain_percentage_tracker_file=$configfolder/maintain.percentage

--- a/setup.sh
+++ b/setup.sh
@@ -7,13 +7,13 @@ echo -e "# Note: this script will ask for your password once or multiple times."
 echo -e "####################################################################\n\n"
 
 # Set environment variables
-tempfolder=~/.battery-tmp
+tempfolder=$(mktemp -d)
 binfolder=/usr/local/bin
 mkdir -p $tempfolder
 
 # Set script value
 calling_user=${1:-"$USER"}
-configfolder=/Users/$calling_user/.battery
+[ -n "$XDG_CONFIG_HOME" ] && configfolder=$XDG_CONFIG_HOME/battery || configfolder=$HOME/.battery
 pidfile=$configfolder/battery.pid
 logfile=$configfolder/battery.log
 

--- a/update.sh
+++ b/update.sh
@@ -4,7 +4,7 @@
 PATH="$PATH:/usr/sbin"
 
 # Set environment variables
-tempfolder=~/.battery-tmp
+tempfolder=$(mktemp -d)
 binfolder=/usr/local/bin
 batteryfolder="$tempfolder/battery"
 mkdir -p $batteryfolder


### PR DESCRIPTION
Regarding #208 

I just patched where ever `$HOME/.battery` is found in the code.

Basically it checks whether the env var `XDG_CONFIG_HOME` is set. If so, set the config dir to `$XDG_CONFIG_HOME/battery`, otherwise fallback to `$HOME/.battery`.

Tell me if I'm missing something :)