### PR TITLE
Add Launch at Login feature

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -1,19 +1,24 @@
-const { app } = require( 'electron' )
-const { alert, log } = require( './modules/helpers' )
-const { set_initial_interface } = require( './modules/interface' )
+const { app } = require('electron')
+const { alert, log } = require('./modules/helpers')
+const { set_initial_interface } = require('./modules/interface')
+const { apply_launch_at_login_setting } = require('./modules/settings')
 
 // Enable auto-updates
-require( 'update-electron-app' )( {
+require('update-electron-app')({
     logger: {
-        log: ( ...data ) => log( `[ update-electron-app ] `, ...data )
+        log: (...data) => log(`[ update-electron-app ] `, ...data)
     }
-} )
+})
 
 /* ///////////////////////////////
 // Event listeners
 // /////////////////////////////*/
 
-app.whenReady().then( set_initial_interface )
+app.whenReady().then(() => {
+    // Apply launch at login setting on startup
+    apply_launch_at_login_setting()
+    set_initial_interface()
+})
 
 /* ///////////////////////////////
 // Global config
@@ -26,13 +31,13 @@ app.dock.hide()
 // Debugging
 // /////////////////////////////*/
 const debug = false
-if( debug ) app.whenReady().then( async () => {
+if (debug) app.whenReady().then(async () => {
 
-    await alert( __dirname )
+    await alert(__dirname)
 
-    await alert( Object.keys( process.env ).join( '\n' ) )
+    await alert(Object.keys(process.env).join('\n'))
 
     const { HOME, PATH, USER } = process.env
-    await alert( `HOME: ${ HOME }\n\nPATH: ${ PATH }\n\nUSER: ${ USER }` )
+    await alert(`HOME: ${HOME}\n\nPATH: ${PATH}\n\nUSER: ${USER}`)
 
-} )
+})

--- a/app/modules/interface.js
+++ b/app/modules/interface.js
@@ -1,8 +1,8 @@
-const { shell, app, Tray, Menu, powerMonitor, nativeTheme } = require( 'electron' )
-const { enable_battery_limiter, disable_battery_limiter, initialize_battery, is_limiter_enabled, get_battery_status, uninstall_battery } = require( './battery' )
-const { log } = require( "./helpers" )
-const { get_logo_template } = require( './theme' )
-const { get_force_discharge_setting, update_force_discharge_setting } = require( './settings' )
+const { shell, app, Tray, Menu, powerMonitor, nativeTheme } = require('electron')
+const { enable_battery_limiter, disable_battery_limiter, initialize_battery, is_limiter_enabled, get_battery_status, uninstall_battery } = require('./battery')
+const { log } = require("./helpers")
+const { get_logo_template } = require('./theme')
+const { get_force_discharge_setting, update_force_discharge_setting, get_launch_at_login_setting, update_launch_at_login_setting } = require('./settings')
 
 /* ///////////////////////////////
 // Menu helpers
@@ -15,7 +15,7 @@ const generate_app_menu = async () => {
 
     try {
         // Get battery and daemon status
-        const { battery_state, daemon_state, maintain_percentage=80, percentage } = await get_battery_status()
+        const { battery_state, daemon_state, maintain_percentage = 80, percentage } = await get_battery_status()
 
         // Check if limiter is on
         const limiter_on = await is_limiter_enabled()
@@ -23,21 +23,23 @@ const generate_app_menu = async () => {
         // Check force discharge setting
         const allow_discharge = get_force_discharge_setting()
 
+        const launch_at_login = get_launch_at_login_setting()
+
         // Set tray icon
-        log( `Generate app menu percentage: ${ percentage } (discharge ${ allow_discharge ? 'allowed' : 'disallowed' }, limited ${ limiter_on ? 'on' : 'off' })` )
-        tray.setImage( get_logo_template( percentage, limiter_on ) )
+        log(`Generate app menu percentage: ${percentage} (discharge ${allow_discharge ? 'allowed' : 'disallowed'}, limited ${limiter_on ? 'on' : 'off'})`)
+        tray.setImage(get_logo_template(percentage, limiter_on))
 
         // Build menu
-        return Menu.buildFromTemplate( [
+        return Menu.buildFromTemplate([
 
             {
-                label: `Enable ${ maintain_percentage }% battery limit`,
+                label: `Enable ${maintain_percentage}% battery limit`,
                 type: 'radio',
                 checked: limiter_on,
                 click: enable_limiter
             },
             {
-                label: `Disable ${ maintain_percentage }% battery limit`,
+                label: `Disable ${maintain_percentage}% battery limit`,
                 type: 'radio',
                 checked: !limiter_on,
                 click: disable_limiter
@@ -46,11 +48,11 @@ const generate_app_menu = async () => {
                 type: 'separator'
             },
             {
-                label: `Battery: ${ battery_state }`,
+                label: `Battery: ${battery_state}`,
                 enabled: false
             },
             {
-                label: `Power: ${ daemon_state }`,
+                label: `Power: ${daemon_state}`,
                 enabled: false
             },
             {
@@ -65,24 +67,36 @@ const generate_app_menu = async () => {
                         checked: allow_discharge,
                         click: async () => {
                             const success = await update_force_discharge_setting()
-                            if( limiter_on && success ) await restart_limiter()
+                            if (limiter_on && success) await restart_limiter()
+                        }
+                    },
+                    {
+                        type: 'separator'
+                    },
+                    {
+                        label: `Launch at Login`,
+                        type: 'checkbox',
+                        checked: launch_at_login,
+                        click: async () => {
+                            await update_launch_at_login_setting()
+                            await refresh_tray()
                         }
                     }
                 ]
             },
             {
-                label: `About v${ app.getVersion() }`,
+                label: `About v${app.getVersion()}`,
                 submenu: [
                     {
                         label: `Check for updates`,
-                        click: () => shell.openExternal( `https://github.com/actuallymentor/battery/releases` )
+                        click: () => shell.openExternal(`https://github.com/actuallymentor/battery/releases`)
                     },
                     {
                         type: 'normal',
-                        label: `Uninstall Battery ${ app.getVersion() }`,
+                        label: `Uninstall Battery ${app.getVersion()}`,
                         click: async () => {
                             const uninstalled = await uninstall_battery()
-                            if( !uninstalled ) return
+                            if (!uninstalled) return
                             tray.destroy()
                             app.quit()
                         }
@@ -92,17 +106,17 @@ const generate_app_menu = async () => {
                     },
                     {
                         label: `User manual`,
-                        click: () => shell.openExternal( `https://github.com/actuallymentor/battery#readme` )
+                        click: () => shell.openExternal(`https://github.com/actuallymentor/battery#readme`)
                     },
                     {
                         type: 'normal',
                         label: 'Command-line usage',
-                        click: () => shell.openExternal( `https://github.com/actuallymentor/battery#-command-line-version` )
+                        click: () => shell.openExternal(`https://github.com/actuallymentor/battery#-command-line-version`)
                     },
                     {
                         type: 'normal',
                         label: 'Help and feature requests',
-                        click: () => shell.openExternal( `https://github.com/actuallymentor/battery/issues` )
+                        click: () => shell.openExternal(`https://github.com/actuallymentor/battery/issues`)
                     }
                 ]
             },
@@ -113,62 +127,62 @@ const generate_app_menu = async () => {
                     app.quit()
                 }
             }
-            
-        ] )
-    } catch ( e ) {
-        log( `Error generating menu: `, e )
+
+        ])
+    } catch (e) {
+        log(`Error generating menu: `, e)
     }
 
 }
 
 // Periodic refreshing of icon and state
 let refresh_timer = undefined
-const set_interface_update_timer = async ( disable_only=false ) => {
+const set_interface_update_timer = async (disable_only = false) => {
 
-    if( !disable_only ) log( `Refreshing interface update timer` )
-    else log( `Disabling interface update timer due to disable_only set to `, disable_only )
+    if (!disable_only) log(`Refreshing interface update timer`)
+    else log(`Disabling interface update timer due to disable_only set to `, disable_only)
 
     // Calculate update speed
-    const { maintain_percentage=80, percentage, charging } = await get_battery_status()
-    const percentage_delta = Math.floor( Math.abs( percentage - maintain_percentage ) )
+    const { maintain_percentage = 80, percentage, charging } = await get_battery_status()
+    const percentage_delta = Math.floor(Math.abs(percentage - maintain_percentage))
     const slow_refresh_interval_in_ms = 1000 * 60 * 10
     const fast_refresh_interval_in_ms = 1000 * 60 * .5
     const battery_full_and_charging = charging && percentage == 100
-    const refresh_speed =  percentage_delta < 5 || powerMonitor.onBatteryPower || battery_full_and_charging  ? slow_refresh_interval_in_ms : fast_refresh_interval_in_ms
-    log( `Setting interface refresh speed to ${ refresh_speed / 1000 / 60 } minutes` )
-    if( refresh_timer ) clearInterval( refresh_timer )
+    const refresh_speed = percentage_delta < 5 || powerMonitor.onBatteryPower || battery_full_and_charging ? slow_refresh_interval_in_ms : fast_refresh_interval_in_ms
+    log(`Setting interface refresh speed to ${refresh_speed / 1000 / 60} minutes`)
+    if (refresh_timer) clearInterval(refresh_timer)
     // eslint-disable-next-line no-use-before-define
-    if( !disable_only ) refresh_timer = setInterval( refresh_tray, refresh_speed )
+    if (!disable_only) refresh_timer = setInterval(refresh_tray, refresh_speed)
 
 }
 
 // Refresh tray with battery status values
-const refresh_tray = async ( force_interactive_refresh = false ) => {
+const refresh_tray = async (force_interactive_refresh = false) => {
 
-    log( "Refreshing tray icon..." )
+    log("Refreshing tray icon...")
     const new_menu = await generate_app_menu()
-    if( force_interactive_refresh ) {
-        log( `Forcing interactive refresh ${ force_interactive_refresh }` )
+    if (force_interactive_refresh) {
+        log(`Forcing interactive refresh ${force_interactive_refresh}`)
         tray.closeContextMenu()
-        tray.popUpContextMenu( new_menu )
+        tray.popUpContextMenu(new_menu)
     }
-    tray.setContextMenu( new_menu )
+    tray.setContextMenu(new_menu)
 
     // Refresh timer 
-    log( `Resetting interface timer speed` )
+    log(`Resetting interface timer speed`)
     set_interface_update_timer()
 
 }
 
 // Refresh app logo
-const refresh_logo = async ( percent=80, force ) => {
+const refresh_logo = async (percent = 80, force) => {
 
-    log( `Refresh logo for percentage ${ percent }, force ${ force }` )
-    if( force == 'active' ) return tray.setImage( get_logo_template( percent, true ) )
-    if( force == 'inactive' ) return tray.setImage( get_logo_template( percent, false ) )
+    log(`Refresh logo for percentage ${percent}, force ${force}`)
+    if (force == 'active') return tray.setImage(get_logo_template(percent, true))
+    if (force == 'inactive') return tray.setImage(get_logo_template(percent, false))
 
     const is_enabled = await is_limiter_enabled()
-    return tray.setImage( get_logo_template( percent, is_enabled ) )
+    return tray.setImage(get_logo_template(percent, is_enabled))
 }
 
 
@@ -177,36 +191,36 @@ const refresh_logo = async ( percent=80, force ) => {
 // /////////////////////////////*/
 async function set_initial_interface() {
 
-    log( "Starting tray app" )
-    tray = new Tray( get_logo_template( 100, true ) )
+    log("Starting tray app")
+    tray = new Tray(get_logo_template(100, true))
 
     // Set "loading" context
-    tray.setTitle( '  updating...' )
-    
-    log( "Tray app boot complete" )
+    tray.setTitle('  updating...')
 
-    log( "Triggering boot-time auto-update" )
+    log("Tray app boot complete")
+
+    log("Triggering boot-time auto-update")
     await initialize_battery()
-    log( "App initialisation process complete" )
+    log("App initialisation process complete")
 
     // Start battery handler
     await enable_battery_limiter()
 
     // Set tray styles
-    tray.setTitle( '' )
+    tray.setTitle('')
     await refresh_tray()
 
     // Set tray open listener
-    tray.on( 'mouse-enter', () => refresh_tray() )
-    tray.on( 'click', () => refresh_tray() )
-    nativeTheme.on( 'updated', () => refresh_tray() )
+    tray.on('mouse-enter', () => refresh_tray())
+    tray.on('click', () => refresh_tray())
+    nativeTheme.on('updated', () => refresh_tray())
 
     // Set refresh timer for the battery icon
     set_interface_update_timer()
-    powerMonitor.on( 'lock-screen', () => set_interface_update_timer( true ) )
-    powerMonitor.on( 'unlock-screen', () => set_interface_update_timer() )
-    powerMonitor.on( 'suspend', () => set_interface_update_timer( true ) )
-    powerMonitor.on( 'resume', () => set_interface_update_timer() )
+    powerMonitor.on('lock-screen', () => set_interface_update_timer(true))
+    powerMonitor.on('unlock-screen', () => set_interface_update_timer())
+    powerMonitor.on('suspend', () => set_interface_update_timer(true))
+    powerMonitor.on('resume', () => set_interface_update_timer())
 
 }
 
@@ -216,14 +230,14 @@ async function set_initial_interface() {
 async function enable_limiter() {
 
     try {
-        log( 'Enable limiter' )
-        await refresh_logo( 80, 'active' )
+        log('Enable limiter')
+        await refresh_logo(80, 'active')
         const percent_left = await enable_battery_limiter()
-        log( `Interface enabled limiter, percentage remaining: ${ percent_left }` )
-        await refresh_logo( percent_left, 'active' )
+        log(`Interface enabled limiter, percentage remaining: ${percent_left}`)
+        await refresh_logo(percent_left, 'active')
         await refresh_tray()
-    } catch ( e ) {
-        log( `Error in enable_limiter: `, e )
+    } catch (e) {
+        log(`Error in enable_limiter: `, e)
     }
 
 }
@@ -231,14 +245,14 @@ async function enable_limiter() {
 async function disable_limiter() {
 
     try {
-        log( 'Disable limiter' )
-        await refresh_logo( 80, 'inactive' )
+        log('Disable limiter')
+        await refresh_logo(80, 'inactive')
         const percent_left = await disable_battery_limiter()
-        log( `Interface enabled limiter, percentage remaining: ${ percent_left }` )
-        await refresh_logo( percent_left, 'inactive' )
+        log(`Interface enabled limiter, percentage remaining: ${percent_left}`)
+        await refresh_logo(percent_left, 'inactive')
         await refresh_tray()
-    } catch ( e ) {
-        log( `Error in disable_limiter: `, e )
+    } catch (e) {
+        log(`Error in disable_limiter: `, e)
     }
 
 }
@@ -246,13 +260,13 @@ async function disable_limiter() {
 async function restart_limiter() {
 
     try {
-        log( 'Restart limiter' )
+        log('Restart limiter')
         const percent_left = await disable_battery_limiter()
         await enable_battery_limiter()
-        await refresh_logo( percent_left, 'active' )
+        await refresh_logo(percent_left, 'active')
         await refresh_tray()
-    } catch ( e ) {
-        log( `Error in restart_limiter: `, e )
+    } catch (e) {
+        log(`Error in restart_limiter: `, e)
     }
 
 }

--- a/app/modules/settings.js
+++ b/app/modules/settings.js
@@ -1,22 +1,26 @@
-const Store = require( 'electron-store' )
-const { log, confirm } = require( './helpers' )
-const store = new Store( {
+const Store = require('electron-store')
+const { app } = require('electron')
+const { log, confirm } = require('./helpers')
+const store = new Store({
     force_discharge_if_needed: {
         type: 'boolean'
+    },
+    launch_at_login: {
+        type: 'boolean'
     }
-} )
+})
 
 const get_force_discharge_setting = () => {
     // Check if force discharge is on
-    const force_discharge_if_needed = store.get( 'force_discharge_if_needed' )
-    log( `Force discharge setting: ${ typeof force_discharge_if_needed } ${ force_discharge_if_needed }` )
+    const force_discharge_if_needed = store.get('force_discharge_if_needed')
+    log(`Force discharge setting: ${typeof force_discharge_if_needed} ${force_discharge_if_needed}`)
     return force_discharge_if_needed === true
 }
 
 const toggle_force_discharge = () => {
     const status = get_force_discharge_setting()
-    log( `Setting force discharge to ${ !status }` )
-    store.set( 'force_discharge_if_needed', !status )
+    log(`Setting force discharge to ${!status}`)
+    store.set('force_discharge_if_needed', !status)
 }
 
 // Update the force discharge setting
@@ -25,9 +29,9 @@ const update_force_discharge_setting = async () => {
     try {
 
         const currently_allowed = get_force_discharge_setting()
-        if( !currently_allowed ) {
-            const proceed = await confirm( `This setting allows your battery to drain to the desired maintenance level while plugged in. This does not work well in Clamshell mode (laptop closed with an external monitor).\n\nAllow force-discharging?` )
-            if( !proceed ) return false
+        if (!currently_allowed) {
+            const proceed = await confirm(`This setting allows your battery to drain to the desired maintenance level while plugged in. This does not work well in Clamshell mode (laptop closed with an external monitor).\n\nAllow force-discharging?`)
+            if (!proceed) return false
         }
 
         // Toggle setting and refresh tray
@@ -35,14 +39,67 @@ const update_force_discharge_setting = async () => {
         return true
 
 
-    } catch ( e ) {
-        log( `Error updating force discharge: `, e )
+    } catch (e) {
+        log(`Error updating force discharge: `, e)
     }
 
+}
+
+const get_launch_at_login_setting = () => {
+    const launch_at_login = store.get('launch_at_login')
+    log(`Launch at login setting: ${typeof launch_at_login} ${launch_at_login}`)
+    return launch_at_login === true
+}
+
+const set_login_item_settings = (openAtLogin) => {
+    let appPath = process.execPath
+    if (process.platform === 'darwin' && appPath.includes('.app/Contents/MacOS/')) {
+        appPath = appPath.substring(0, appPath.indexOf('.app/') + 5) + 'app'
+    }
+
+    const loginItemSettings = {
+        openAtLogin,
+        openAsHidden: false,
+        name: app.getName(),
+        path: appPath
+    }
+
+    app.setLoginItemSettings(loginItemSettings)
+}
+
+const update_launch_at_login_setting = async () => {
+    try {
+        const currently_enabled = get_launch_at_login_setting()
+        const new_setting = !currently_enabled
+
+        log(`Setting launch at login to ${new_setting}`)
+        store.set('launch_at_login', new_setting)
+
+        set_login_item_settings(new_setting)
+
+        return true
+    } catch (e) {
+        log(`Error updating launch at login: `, e)
+        return false
+    }
+}
+
+const apply_launch_at_login_setting = () => {
+    try {
+        const launch_at_login = get_launch_at_login_setting()
+        log(`Applying launch at login setting: ${launch_at_login}`)
+
+        set_login_item_settings(launch_at_login)
+    } catch (e) {
+        log(`Error applying launch at login: `, e)
+    }
 }
 
 module.exports = {
     get_force_discharge_setting,
     toggle_force_discharge,
-    update_force_discharge_setting
+    update_force_discharge_setting,
+    get_launch_at_login_setting,
+    update_launch_at_login_setting,
+    apply_launch_at_login_setting
 }


### PR DESCRIPTION
- Add 'Launch at Login' option to Advanced settings submenu
- Persist setting using electron-store
- Use app bundle path (not executable path) for macOS compatibility
- Apply setting on app startup to ensure it's always in sync
- Setting appears in System Settings > General > Login Items when enabled

Tested (Macbook Pro Apple Silicon M4 Pro):
- Enabled/disabled launch at login from menu
- Verified setting persists across app restarts
- Confirmed app launches automatically after logout/login
- Tested with app in /Applications (required for login items to work)