### PR TITLE
Fix menu bar icon not appearing on macOS Sequoia (issue #427)

### DIFF
--- a/app/modules/theme.js
+++ b/app/modules/theme.js
@@ -25,7 +25,9 @@ const get_logo_template = ( percent = 100, active ) => {
     const image_path = path.join( asset_path, `/battery-${ active ? 'active' : 'inactive' }-${ display_percentage }-Template.png` )
     const exists = existsSync( image_path )
     log( `${ exists ? 'Found' : '🚨 Missing' } image: ${ image_path }` )
-    return nativeImage.createFromPath( image_path )
+    const image = nativeImage.createFromPath( image_path )
+    image.setTemplateImage( true )
+    return image
 }
 
 /* ///////////////////////////////


### PR DESCRIPTION
## Summary

This PR fixes issue #427 where the menu bar icon is not visible on macOS Sequoia 15.x / Darwin 26.x.

## Changes

- Modified `app/modules/theme.js` to explicitly set template mode on tray icon images using `setTemplateImage(true)`
- This ensures proper rendering of the menu bar icon on newer macOS versions

## Root Cause

The `nativeImage.createFromPath()` method was not explicitly declaring the image as a template image. On macOS Sequoia, this causes the icon to not display properly in the menu bar, even though the app is running and the image file is found.

## Solution

By calling `image.setTemplateImage(true)` after creating the native image, we explicitly mark it as a template image. This follows Electron's best practices for menu bar icons and ensures compatibility with macOS Sequoia's menu bar rendering.

## Testing

- Tested on macOS Sequoia 26.1 (Build 25B78) with Apple Silicon
- Menu bar icon now appears correctly and updates as expected
- All battery functionality continues to work normally

## Test Plan

- [x] Install and run the app in development mode
- [x] Verify menu bar icon appears
- [x] Verify icon updates based on battery percentage
- [x] Verify all battery management functionality works

Closes #427

🤖 Generated with [Claude Code](https://claude.com/claude-code)