### PR TITLE
Add custom charge limit submenu with presets

### DIFF
--- a/app/modules/battery.js
+++ b/app/modules/battery.js
@@ -1,80 +1,80 @@
 // Command line interactors
-const { app } = require( 'electron' )
-const { exec } = require( 'node:child_process' )
-const { log, alert, wait, confirm } = require( './helpers' )
-const { get_force_discharge_setting } = require( './settings' )
+const { app } = require('electron')
+const { exec } = require('node:child_process')
+const { log, alert, wait, confirm } = require('./helpers')
+const { get_force_discharge_setting } = require('./settings')
 const { USER } = process.env
 const path_fix = 'PATH=/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin'
-const battery = `${ path_fix } battery`
+const battery = `${path_fix} battery`
 const shell_options = {
     shell: '/bin/bash',
-    env: { ...process.env, PATH: `${ process.env.PATH }:/usr/local/bin` }
+    env: { ...process.env, PATH: `${process.env.PATH}:/usr/local/bin` }
 }
 
 // Execute without sudo
-const exec_async_no_timeout = command => new Promise( ( resolve, reject ) => {
+const exec_async_no_timeout = command => new Promise((resolve, reject) => {
 
-    log( `Executing ${ command }` )
+    log(`Executing ${command}`)
 
-    exec( command, shell_options, ( error, stdout, stderr ) => {
+    exec(command, shell_options, (error, stdout, stderr) => {
 
-        if( error ) return reject( error, stderr, stdout )
-        if( stderr ) return reject( stderr )
-        if( stdout ) return resolve( stdout )
-        if( !stdout ) return resolve( '' )
+        if (error) return reject(error, stderr, stdout)
+        if (stderr) return reject(stderr)
+        if (stdout) return resolve(stdout)
+        if (!stdout) return resolve('')
 
-    } )
+    })
 
-} )
+})
 
-const exec_async = ( command, timeout_in_ms=2000, throw_on_timeout=false ) => Promise.race( [
-    exec_async_no_timeout( command ),
-    wait( timeout_in_ms ).then( () => {
-        if( throw_on_timeout ) throw new Error( `${ command } timed out` )
-    } )
-] )
+const exec_async = (command, timeout_in_ms = 2000, throw_on_timeout = false) => Promise.race([
+    exec_async_no_timeout(command),
+    wait(timeout_in_ms).then(() => {
+        if (throw_on_timeout) throw new Error(`${command} timed out`)
+    })
+])
 
 // Execute with sudo
-const exec_sudo_async = command => new Promise( ( resolve, reject ) => {
+const exec_sudo_async = command => new Promise((resolve, reject) => {
 
-    log( `Executing ${ command } by running:` )
-    log( `osascript -e "do shell script \\"${ command }\\" with administrator privileges"` )
+    log(`Executing ${command} by running:`)
+    log(`osascript -e "do shell script \\"${command}\\" with administrator privileges"`)
 
-    exec( `osascript -e "do shell script \\"${ command }\\" with administrator privileges"`, shell_options, ( error, stdout, stderr ) => {
+    exec(`osascript -e "do shell script \\"${command}\\" with administrator privileges"`, shell_options, (error, stdout, stderr) => {
 
-        if( error ) return reject( error, stderr, stdout )
-        if( stderr ) return reject( stderr )
-        if( stdout ) return resolve( stdout )
-        if( !stdout ) return resolve( '' )
+        if (error) return reject(error, stderr, stdout)
+        if (stderr) return reject(stderr)
+        if (stdout) return resolve(stdout)
+        if (!stdout) return resolve('')
 
-    } )
+    })
 
-} )
+})
 
 // Battery status checker
 const get_battery_status = async () => {
 
     try {
-        const message = await exec_async( `${ battery } status_csv` )
-        let [ percentage='??', remaining='', charging='', discharging='', maintain_percentage='' ] = message?.split( ',' ) || []
+        const message = await exec_async(`${battery} status_csv`)
+        let [percentage = '??', remaining = '', charging = '', discharging = '', maintain_percentage = ''] = message?.split(',') || []
         maintain_percentage = maintain_percentage.trim()
         maintain_percentage = maintain_percentage.length ? maintain_percentage : undefined
         charging = charging == 'enabled'
         discharging = discharging == 'discharging'
-        remaining = remaining.match( /\d{1,2}:\d{1,2}/ ) ? remaining : 'unknown'
+        remaining = remaining.match(/\d{1,2}:\d{1,2}/) ? remaining : 'unknown'
 
-        let battery_state = `${ percentage }% (${ remaining } remaining)`
+        let battery_state = `${percentage}% (${remaining} remaining)`
         let daemon_state = ``
-        if( discharging ) daemon_state += `forcing discharge to ${ maintain_percentage || 80 }%`
-        else daemon_state += `smc charging ${ charging ? 'enabled' : 'disabled' }`
+        if (discharging) daemon_state += `forcing discharge to ${maintain_percentage || 80}%`
+        else daemon_state += `smc charging ${charging ? 'enabled' : 'disabled'}`
 
         const status_object = { percentage, remaining, charging, discharging, maintain_percentage, battery_state, daemon_state }
-        log( 'Battery status: ', JSON.stringify( status_object ) )
+        log('Battery status: ', JSON.stringify(status_object))
         return status_object
 
-    } catch ( e ) {
-        log( `Error getting battery status: `, e )
-        alert( `Battery limiter error: ${ e.message }` )
+    } catch (e) {
+        log(`Error getting battery status: `, e)
+        alert(`Battery limiter error: ${e.message}`)
     }
 
 }
@@ -89,12 +89,12 @@ const enable_battery_limiter = async () => {
         // Start battery maintainer
         const status = await get_battery_status()
         const allow_force_discharge = get_force_discharge_setting()
-        await exec_async( `${ battery } maintain ${ status?.maintain_percentage || 80 }${ allow_force_discharge ? ' --force-discharge' : '' }` )
-        log( `enable_battery_limiter exec complete` )
+        await exec_async(`${battery} maintain ${status?.maintain_percentage || 80}${allow_force_discharge ? ' --force-discharge' : ''}`)
+        log(`enable_battery_limiter exec complete`)
         return status?.percentage
-    } catch ( e ) {
-        log( 'Error enabling battery: ', e )
-        alert( e.message )
+    } catch (e) {
+        log('Error enabling battery: ', e)
+        alert(e.message)
     }
 
 }
@@ -102,18 +102,18 @@ const enable_battery_limiter = async () => {
 const disable_battery_limiter = async () => {
 
     try {
-        await exec_async( `${ battery } maintain stop` )
+        await exec_async(`${battery} maintain stop`)
         const status = await get_battery_status()
         return status?.percentage
-    } catch ( e ) {
-        log( 'Error enabling battery: ', e )
-        alert( e.message )
+    } catch (e) {
+        log('Error enabling battery: ', e)
+        alert(e.message)
     }
 
 }
 
-const low_err_return_false = ( ...errdata ) => {
-    log( 'Error in shell call: ', ...errdata )
+const low_err_return_false = (...errdata) => {
+    log('Error in shell call: ', ...errdata)
     return false
 }
 
@@ -123,14 +123,14 @@ const initialize_battery = async () => {
 
         // Check if dev mode
         const { development, skipupdate } = process.env
-        if( development ) log( `Dev mode on, skip updates: ${ skipupdate }` )
+        if (development) log(`Dev mode on, skip updates: ${skipupdate}`)
 
         // Check for network
-        const online = await Promise.race( [
-            exec_async( `${ path_fix } curl -I https://icanhazip.com &> /dev/null` ).then( () => true ).catch( () => false ),
-            exec_async( `${ path_fix } curl -I https://github.com &> /dev/null` ).then( () => true ).catch( () => false )
-        ] )
-        log( `Internet online: ${ online }` )
+        const online = await Promise.race([
+            exec_async(`${path_fix} curl -I https://icanhazip.com &> /dev/null`).then(() => true).catch(() => false),
+            exec_async(`${path_fix} curl -I https://github.com &> /dev/null`).then(() => true).catch(() => false)
+        ])
+        log(`Internet online: ${online}`)
 
         // Check if battery is installed and visudo entries are complete. New visudo entries are added when we do new `sudo` stuff in battery.sh
         // note to self: only added a few of the new entries, there is no need to be exhaustive except to make sure all new sudo stuff is covered
@@ -152,65 +152,65 @@ const initialize_battery = async () => {
             magsafe_led_in_visudo,
             chte_charging_in_visudo,
             chie_discharging_in_visudo,
-        ] = await Promise.all( [
-            exec_async( `${ path_fix } which battery` ).catch( low_err_return_false ),
-            exec_async( `${ path_fix } which smc` ).catch( low_err_return_false ),
-            ...smc_commands.map( cmd => exec_async( `${ path_fix } sudo -n /usr/local/bin/smc ${ cmd }` ).catch( low_err_return_false ) )
-        ] )
+        ] = await Promise.all([
+            exec_async(`${path_fix} which battery`).catch(low_err_return_false),
+            exec_async(`${path_fix} which smc`).catch(low_err_return_false),
+            ...smc_commands.map(cmd => exec_async(`${path_fix} sudo -n /usr/local/bin/smc ${cmd}`).catch(low_err_return_false))
+        ])
 
-        const visudo_complete = ![ charging_in_visudo,  discharging_in_visudo,  magsafe_led_in_visudo, chte_charging_in_visudo, chie_discharging_in_visudo ].some( entry => entry === false )
+        const visudo_complete = ![charging_in_visudo, discharging_in_visudo, magsafe_led_in_visudo, chte_charging_in_visudo, chie_discharging_in_visudo].some(entry => entry === false)
         const is_installed = battery_installed && smc_installed
-        log( 'Is installed? ', is_installed )
-        log( 'Visudo complete? ', {
+        log('Is installed? ', is_installed)
+        log('Visudo complete? ', {
             charging_in_visudo,
             discharging_in_visudo,
             magsafe_led_in_visudo,
             chte_charging_in_visudo,
             chie_discharging_in_visudo,
             visudo_complete
-        } )
+        })
 
         // Kill running instances of battery
-        const processes = await exec_async( `ps aux | grep "/usr/local/bin/battery " | wc -l | grep -Eo "\\d*"` )
-        log( `Found ${ `${ processes }`.replace( /\n/, '' ) } battery related processed to kill` )
-        if( is_installed ) await exec_async( `${ battery } maintain stop` )
-        await exec_async( `pkill -f "/usr/local/bin/battery.*"` ).catch( e => log( `Error killing existing battery progesses, usually means no running processes` ) )
+        const processes = await exec_async(`ps aux | grep "/usr/local/bin/battery " | wc -l | grep -Eo "\\d*"`)
+        log(`Found ${`${processes}`.replace(/\n/, '')} battery related processed to kill`)
+        if (is_installed) await exec_async(`${battery} maintain stop`)
+        await exec_async(`pkill -f "/usr/local/bin/battery.*"`).catch(e => log(`Error killing existing battery progesses, usually means no running processes`))
 
         // If installed, update
-        if( is_installed && visudo_complete ) {
-            if( !online ) return log( `Skipping battery update because we are offline` )
-            if( skipupdate ) return log( `Skipping update due to environment variable` )
-            log( `Updating battery...` )
-            const result = await exec_async( `${ battery } update silent` ).catch( e => e )
-            log( `Update result: `, result )
+        if (is_installed && visudo_complete) {
+            if (!online) return log(`Skipping battery update because we are offline`)
+            if (skipupdate) return log(`Skipping update due to environment variable`)
+            log(`Updating battery...`)
+            const result = await exec_async(`${battery} update silent`).catch(e => e)
+            log(`Update result: `, result)
         }
 
         // If not installed, run install script
-        if( !is_installed ) {
-            log( `Installing battery for ${ USER }...` )
-            if( !online ) return alert( `Battery needs an internet connection to download the latest version, please connect to the internet and open the app again.` )
-            if( !is_installed ) await alert( `Welcome to the Battery limiting tool. The app needs to install/update some components, so it will ask for your password. This should only be needed once.` )
-            const result = await exec_sudo_async( `curl -s https://raw.githubusercontent.com/actuallymentor/battery/main/setup.sh | bash -s -- $USER` )
-            log( `Install result success `, result )
-            await alert( `Battery background components installed successfully. You can find the battery limiter icon in the top right of your menu bar.` )
+        if (!is_installed) {
+            log(`Installing battery for ${USER}...`)
+            if (!online) return alert(`Battery needs an internet connection to download the latest version, please connect to the internet and open the app again.`)
+            if (!is_installed) await alert(`Welcome to the Battery limiting tool. The app needs to install/update some components, so it will ask for your password. This should only be needed once.`)
+            const result = await exec_sudo_async(`curl -s https://raw.githubusercontent.com/actuallymentor/battery/main/setup.sh | bash -s -- $USER`)
+            log(`Install result success `, result)
+            await alert(`Battery background components installed successfully. You can find the battery limiter icon in the top right of your menu bar.`)
         }
 
         // If visudo entries are incomplete, update
-        if( !visudo_complete ) {
-            await alert( `Battery needs to apply a backwards incompatible update, to do this it will ask for your password. This should not happen frequently.` )
-            await exec_sudo_async( `${ path_fix } battery visudo` )
+        if (!visudo_complete) {
+            await alert(`Battery needs to apply a backwards incompatible update, to do this it will ask for your password. This should not happen frequently.`)
+            await exec_sudo_async(`${path_fix} battery visudo`)
         }
 
         // Recover old battery setting on boot (as we killed all old processes above)
-        await exec_async( `${ battery } maintain recover` )
+        await exec_async(`${battery} maintain recover`)
 
         // Basic user tracking on app open, run it in the background so it does not cause any delay for the user
-        if( online ) exec_async( `nohup curl "https://unidentifiedanalytics.web.app/touch/?namespace=battery" > /dev/null 2>&1` )
+        if (online) exec_async(`nohup curl "https://unidentifiedanalytics.web.app/touch/?namespace=battery" > /dev/null 2>&1`)
 
 
-    } catch ( e ) {
-        log( `Update/install error: `, e )
-        await alert( `Error installing battery limiter: ${ e.message }` )
+    } catch (e) {
+        log(`Update/install error: `, e)
+        await alert(`Error installing battery limiter: ${e.message}`)
         app.quit()
         app.exit()
     }
@@ -220,14 +220,14 @@ const initialize_battery = async () => {
 const uninstall_battery = async () => {
 
     try {
-        const confirmed = await confirm( `Are you sure you want to uninstall Battery?` )
-        if( !confirmed ) return false
-        await exec_sudo_async( `${ path_fix } sudo battery uninstall silent` )
-        await alert( `Battery is now uninstalled!` )
+        const confirmed = await confirm(`Are you sure you want to uninstall Battery?`)
+        if (!confirmed) return false
+        await exec_sudo_async(`${path_fix} sudo battery uninstall silent`)
+        await alert(`Battery is now uninstalled!`)
         return true
-    } catch ( e ) {
-        log( 'Error uninstalling battery: ', e )
-        alert( `Error uninstalling battery: ${ e.message }` )
+    } catch (e) {
+        log('Error uninstalling battery: ', e)
+        alert(`Error uninstalling battery: ${e.message}`)
         return false
     }
 
@@ -237,12 +237,28 @@ const uninstall_battery = async () => {
 const is_limiter_enabled = async () => {
 
     try {
-        const message = await exec_async( `${ battery } status` )
-        log( `Limiter status message: `, message )
-        return message?.includes( 'being maintained at' )
-    } catch ( e ) {
-        log( `Error getting battery status: `, e )
-        alert( `Battery limiter error: ${ e.message }` )
+        const message = await exec_async(`${battery} status`)
+        log(`Limiter status message: `, message)
+        return message?.includes('being maintained at')
+    } catch (e) {
+        log(`Error getting battery status: `, e)
+        alert(`Battery limiter error: ${e.message}`)
+    }
+
+}
+
+const enable_battery_limiter_at = async (percent) => {
+
+    try {
+        // Start battery maintainer at a specific percentage
+        const allow_force_discharge = get_force_discharge_setting()
+        await exec_async(`${battery} maintain ${percent}${allow_force_discharge ? ' --force-discharge' : ''}`)
+        log(`enable_battery_limiter_at ${percent} exec complete`)
+        const status = await get_battery_status()
+        return status?.percentage
+    } catch (e) {
+        log('Error enabling battery at custom percentage: ', e)
+        alert(e.message)
     }
 
 }
@@ -250,6 +266,7 @@ const is_limiter_enabled = async () => {
 
 module.exports = {
     enable_battery_limiter,
+    enable_battery_limiter_at,
     disable_battery_limiter,
     initialize_battery,
     is_limiter_enabled,

--- a/app/modules/interface.js
+++ b/app/modules/interface.js
@@ -1,21 +1,23 @@
-const { shell, app, Tray, Menu, powerMonitor, nativeTheme } = require( 'electron' )
-const { enable_battery_limiter, disable_battery_limiter, initialize_battery, is_limiter_enabled, get_battery_status, uninstall_battery } = require( './battery' )
-const { log } = require( "./helpers" )
-const { get_logo_template } = require( './theme' )
-const { get_force_discharge_setting, update_force_discharge_setting } = require( './settings' )
+const { shell, app, Tray, Menu, powerMonitor, nativeTheme } = require('electron')
+const { enable_battery_limiter, enable_battery_limiter_at, disable_battery_limiter, initialize_battery, is_limiter_enabled, get_battery_status, uninstall_battery } = require('./battery')
+const { log } = require("./helpers")
+const { get_logo_template } = require('./theme')
+const { get_force_discharge_setting, update_force_discharge_setting, get_custom_percentage, set_custom_percentage } = require('./settings')
 
 /* ///////////////////////////////
 // Menu helpers
 // /////////////////////////////*/
 let tray = undefined
 
+// Preset charge limit values available in the submenu
+const charge_limit_presets = [60, 70, 75, 80, 90, 100]
 
 // Set interface to usable
 const generate_app_menu = async () => {
 
     try {
         // Get battery and daemon status
-        const { battery_state, daemon_state, maintain_percentage=80, percentage } = await get_battery_status()
+        const { battery_state, daemon_state, maintain_percentage = 80, percentage } = await get_battery_status()
 
         // Check if limiter is on
         const limiter_on = await is_limiter_enabled()
@@ -23,21 +25,37 @@ const generate_app_menu = async () => {
         // Check force discharge setting
         const allow_discharge = get_force_discharge_setting()
 
+        // Get the user's custom charge limit percentage
+        const custom_percent = get_custom_percentage()
+
         // Set tray icon
-        log( `Generate app menu percentage: ${ percentage } (discharge ${ allow_discharge ? 'allowed' : 'disallowed' }, limited ${ limiter_on ? 'on' : 'off' })` )
-        tray.setImage( get_logo_template( percentage, limiter_on ) )
+        log(`Generate app menu percentage: ${percentage} (discharge ${allow_discharge ? 'allowed' : 'disallowed'}, limited ${limiter_on ? 'on' : 'off'}, custom limit ${custom_percent}%)`)
+        tray.setImage(get_logo_template(percentage, limiter_on))
+
+        // Build the "Set charge limit" submenu with preset values
+        const charge_limit_submenu = charge_limit_presets.map(preset => ({
+            label: `${preset}%`,
+            type: 'radio',
+            checked: custom_percent === preset,
+            click: async () => {
+                set_custom_percentage(preset)
+                // If the limiter is currently on, restart it with the new percentage
+                if (limiter_on) await restart_limiter_at(preset)
+                await refresh_tray()
+            }
+        }))
 
         // Build menu
-        return Menu.buildFromTemplate( [
+        return Menu.buildFromTemplate([
 
             {
-                label: `Enable ${ maintain_percentage }% battery limit`,
+                label: `Enable battery limit at ${custom_percent}%`,
                 type: 'radio',
                 checked: limiter_on,
                 click: enable_limiter
             },
             {
-                label: `Disable ${ maintain_percentage }% battery limit`,
+                label: `Disable battery limit`,
                 type: 'radio',
                 checked: !limiter_on,
                 click: disable_limiter
@@ -46,11 +64,18 @@ const generate_app_menu = async () => {
                 type: 'separator'
             },
             {
-                label: `Battery: ${ battery_state }`,
+                label: `Set charge limit`,
+                submenu: charge_limit_submenu
+            },
+            {
+                type: 'separator'
+            },
+            {
+                label: `Battery: ${battery_state}`,
                 enabled: false
             },
             {
-                label: `Power: ${ daemon_state }`,
+                label: `Power: ${daemon_state}`,
                 enabled: false
             },
             {
@@ -65,24 +90,24 @@ const generate_app_menu = async () => {
                         checked: allow_discharge,
                         click: async () => {
                             const success = await update_force_discharge_setting()
-                            if( limiter_on && success ) await restart_limiter()
+                            if (limiter_on && success) await restart_limiter()
                         }
                     }
                 ]
             },
             {
-                label: `About v${ app.getVersion() }`,
+                label: `About v${app.getVersion()}`,
                 submenu: [
                     {
                         label: `Check for updates`,
-                        click: () => shell.openExternal( `https://github.com/actuallymentor/battery/releases` )
+                        click: () => shell.openExternal(`https://github.com/actuallymentor/battery/releases`)
                     },
                     {
                         type: 'normal',
-                        label: `Uninstall Battery ${ app.getVersion() }`,
+                        label: `Uninstall Battery ${app.getVersion()}`,
                         click: async () => {
                             const uninstalled = await uninstall_battery()
-                            if( !uninstalled ) return
+                            if (!uninstalled) return
                             tray.destroy()
                             app.quit()
                         }
@@ -92,17 +117,17 @@ const generate_app_menu = async () => {
                     },
                     {
                         label: `User manual`,
-                        click: () => shell.openExternal( `https://github.com/actuallymentor/battery#readme` )
+                        click: () => shell.openExternal(`https://github.com/actuallymentor/battery#readme`)
                     },
                     {
                         type: 'normal',
                         label: 'Command-line usage',
-                        click: () => shell.openExternal( `https://github.com/actuallymentor/battery#-command-line-version` )
+                        click: () => shell.openExternal(`https://github.com/actuallymentor/battery#-command-line-version`)
                     },
                     {
                         type: 'normal',
                         label: 'Help and feature requests',
-                        click: () => shell.openExternal( `https://github.com/actuallymentor/battery/issues` )
+                        click: () => shell.openExternal(`https://github.com/actuallymentor/battery/issues`)
                     }
                 ]
             },
@@ -113,62 +138,62 @@ const generate_app_menu = async () => {
                     app.quit()
                 }
             }
-            
-        ] )
-    } catch ( e ) {
-        log( `Error generating menu: `, e )
+
+        ])
+    } catch (e) {
+        log(`Error generating menu: `, e)
     }
 
 }
 
 // Periodic refreshing of icon and state
 let refresh_timer = undefined
-const set_interface_update_timer = async ( disable_only=false ) => {
+const set_interface_update_timer = async (disable_only = false) => {
 
-    if( !disable_only ) log( `Refreshing interface update timer` )
-    else log( `Disabling interface update timer due to disable_only set to `, disable_only )
+    if (!disable_only) log(`Refreshing interface update timer`)
+    else log(`Disabling interface update timer due to disable_only set to `, disable_only)
 
     // Calculate update speed
-    const { maintain_percentage=80, percentage, charging } = await get_battery_status()
-    const percentage_delta = Math.floor( Math.abs( percentage - maintain_percentage ) )
+    const { maintain_percentage = 80, percentage, charging } = await get_battery_status()
+    const percentage_delta = Math.floor(Math.abs(percentage - maintain_percentage))
     const slow_refresh_interval_in_ms = 1000 * 60 * 10
     const fast_refresh_interval_in_ms = 1000 * 60 * .5
     const battery_full_and_charging = charging && percentage == 100
-    const refresh_speed =  percentage_delta < 5 || powerMonitor.onBatteryPower || battery_full_and_charging  ? slow_refresh_interval_in_ms : fast_refresh_interval_in_ms
-    log( `Setting interface refresh speed to ${ refresh_speed / 1000 / 60 } minutes` )
-    if( refresh_timer ) clearInterval( refresh_timer )
+    const refresh_speed = percentage_delta < 5 || powerMonitor.onBatteryPower || battery_full_and_charging ? slow_refresh_interval_in_ms : fast_refresh_interval_in_ms
+    log(`Setting interface refresh speed to ${refresh_speed / 1000 / 60} minutes`)
+    if (refresh_timer) clearInterval(refresh_timer)
     // eslint-disable-next-line no-use-before-define
-    if( !disable_only ) refresh_timer = setInterval( refresh_tray, refresh_speed )
+    if (!disable_only) refresh_timer = setInterval(refresh_tray, refresh_speed)
 
 }
 
 // Refresh tray with battery status values
-const refresh_tray = async ( force_interactive_refresh = false ) => {
+const refresh_tray = async (force_interactive_refresh = false) => {
 
-    log( "Refreshing tray icon..." )
+    log("Refreshing tray icon...")
     const new_menu = await generate_app_menu()
-    if( force_interactive_refresh ) {
-        log( `Forcing interactive refresh ${ force_interactive_refresh }` )
+    if (force_interactive_refresh) {
+        log(`Forcing interactive refresh ${force_interactive_refresh}`)
         tray.closeContextMenu()
-        tray.popUpContextMenu( new_menu )
+        tray.popUpContextMenu(new_menu)
     }
-    tray.setContextMenu( new_menu )
+    tray.setContextMenu(new_menu)
 
     // Refresh timer 
-    log( `Resetting interface timer speed` )
+    log(`Resetting interface timer speed`)
     set_interface_update_timer()
 
 }
 
 // Refresh app logo
-const refresh_logo = async ( percent=80, force ) => {
+const refresh_logo = async (percent = 80, force) => {
 
-    log( `Refresh logo for percentage ${ percent }, force ${ force }` )
-    if( force == 'active' ) return tray.setImage( get_logo_template( percent, true ) )
-    if( force == 'inactive' ) return tray.setImage( get_logo_template( percent, false ) )
+    log(`Refresh logo for percentage ${percent}, force ${force}`)
+    if (force == 'active') return tray.setImage(get_logo_template(percent, true))
+    if (force == 'inactive') return tray.setImage(get_logo_template(percent, false))
 
     const is_enabled = await is_limiter_enabled()
-    return tray.setImage( get_logo_template( percent, is_enabled ) )
+    return tray.setImage(get_logo_template(percent, is_enabled))
 }
 
 
@@ -177,36 +202,36 @@ const refresh_logo = async ( percent=80, force ) => {
 // /////////////////////////////*/
 async function set_initial_interface() {
 
-    log( "Starting tray app" )
-    tray = new Tray( get_logo_template( 100, true ) )
+    log("Starting tray app")
+    tray = new Tray(get_logo_template(100, true))
 
     // Set "loading" context
-    tray.setTitle( '  updating...' )
-    
-    log( "Tray app boot complete" )
+    tray.setTitle('  updating...')
 
-    log( "Triggering boot-time auto-update" )
+    log("Tray app boot complete")
+
+    log("Triggering boot-time auto-update")
     await initialize_battery()
-    log( "App initialisation process complete" )
+    log("App initialisation process complete")
 
     // Start battery handler
     await enable_battery_limiter()
 
     // Set tray styles
-    tray.setTitle( '' )
+    tray.setTitle('')
     await refresh_tray()
 
     // Set tray open listener
-    tray.on( 'mouse-enter', () => refresh_tray() )
-    tray.on( 'click', () => refresh_tray() )
-    nativeTheme.on( 'updated', () => refresh_tray() )
+    tray.on('mouse-enter', () => refresh_tray())
+    tray.on('click', () => refresh_tray())
+    nativeTheme.on('updated', () => refresh_tray())
 
     // Set refresh timer for the battery icon
     set_interface_update_timer()
-    powerMonitor.on( 'lock-screen', () => set_interface_update_timer( true ) )
-    powerMonitor.on( 'unlock-screen', () => set_interface_update_timer() )
-    powerMonitor.on( 'suspend', () => set_interface_update_timer( true ) )
-    powerMonitor.on( 'resume', () => set_interface_update_timer() )
+    powerMonitor.on('lock-screen', () => set_interface_update_timer(true))
+    powerMonitor.on('unlock-screen', () => set_interface_update_timer())
+    powerMonitor.on('suspend', () => set_interface_update_timer(true))
+    powerMonitor.on('resume', () => set_interface_update_timer())
 
 }
 
@@ -216,14 +241,15 @@ async function set_initial_interface() {
 async function enable_limiter() {
 
     try {
-        log( 'Enable limiter' )
-        await refresh_logo( 80, 'active' )
-        const percent_left = await enable_battery_limiter()
-        log( `Interface enabled limiter, percentage remaining: ${ percent_left }` )
-        await refresh_logo( percent_left, 'active' )
+        const custom_percent = get_custom_percentage()
+        log(`Enable limiter at ${custom_percent}%`)
+        await refresh_logo(custom_percent, 'active')
+        const percent_left = await enable_battery_limiter_at(custom_percent)
+        log(`Interface enabled limiter at ${custom_percent}%, percentage remaining: ${percent_left}`)
+        await refresh_logo(percent_left, 'active')
         await refresh_tray()
-    } catch ( e ) {
-        log( `Error in enable_limiter: `, e )
+    } catch (e) {
+        log(`Error in enable_limiter: `, e)
     }
 
 }
@@ -231,14 +257,14 @@ async function enable_limiter() {
 async function disable_limiter() {
 
     try {
-        log( 'Disable limiter' )
-        await refresh_logo( 80, 'inactive' )
+        log('Disable limiter')
+        await refresh_logo(80, 'inactive')
         const percent_left = await disable_battery_limiter()
-        log( `Interface enabled limiter, percentage remaining: ${ percent_left }` )
-        await refresh_logo( percent_left, 'inactive' )
+        log(`Interface disabled limiter, percentage remaining: ${percent_left}`)
+        await refresh_logo(percent_left, 'inactive')
         await refresh_tray()
-    } catch ( e ) {
-        log( `Error in disable_limiter: `, e )
+    } catch (e) {
+        log(`Error in disable_limiter: `, e)
     }
 
 }
@@ -246,13 +272,28 @@ async function disable_limiter() {
 async function restart_limiter() {
 
     try {
-        log( 'Restart limiter' )
+        log('Restart limiter')
+        const custom_percent = get_custom_percentage()
         const percent_left = await disable_battery_limiter()
-        await enable_battery_limiter()
-        await refresh_logo( percent_left, 'active' )
+        await enable_battery_limiter_at(custom_percent)
+        await refresh_logo(percent_left, 'active')
         await refresh_tray()
-    } catch ( e ) {
-        log( `Error in restart_limiter: `, e )
+    } catch (e) {
+        log(`Error in restart_limiter: `, e)
+    }
+
+}
+
+async function restart_limiter_at(percent) {
+
+    try {
+        log(`Restart limiter at ${percent}%`)
+        await disable_battery_limiter()
+        const percent_left = await enable_battery_limiter_at(percent)
+        await refresh_logo(percent_left, 'active')
+        await refresh_tray()
+    } catch (e) {
+        log(`Error in restart_limiter_at: `, e)
     }
 
 }

--- a/app/modules/settings.js
+++ b/app/modules/settings.js
@@ -3,6 +3,9 @@ const { log, confirm } = require( './helpers' )
 const store = new Store( {
     force_discharge_if_needed: {
         type: 'boolean'
+    },
+    custom_percentage: {
+        type: 'number'
     }
 } )
 
@@ -41,8 +44,25 @@ const update_force_discharge_setting = async () => {
 
 }
 
+// Get the custom charge percentage (defaults to 80)
+const get_custom_percentage = () => {
+    const custom_percentage = store.get( 'custom_percentage' )
+    log( `Custom percentage setting: ${ custom_percentage }` )
+    return typeof custom_percentage === 'number' ? custom_percentage : 80
+}
+
+// Set the custom charge percentage (clamped between 20 and 100)
+const set_custom_percentage = ( value ) => {
+    const clamped = Math.max( 20, Math.min( 100, Math.round( value ) ) )
+    log( `Setting custom percentage to ${ clamped }` )
+    store.set( 'custom_percentage', clamped )
+    return clamped
+}
+
 module.exports = {
     get_force_discharge_setting,
     toggle_force_discharge,
-    update_force_discharge_setting
+    update_force_discharge_setting,
+    get_custom_percentage,
+    set_custom_percentage
 }


### PR DESCRIPTION
This PR introduces the ability for users to select a specific battery charge limit (e.g., 60%, 70%, 90%) directly from the menu bar app. Previously, the app was hardcoded to toggle only at 80%. The new "Set charge limit" submenu allows for granular control while maintaining the existing "Enable/Disable" workflow. + space removals Description
Feature Changes:

New Submenu: Added a "Set charge limit" menu containing presets: 60%, 70%, 75%, 80%, 90%, and 100%.
Dynamic Labels: The main "Enable" button now dynamically reads "Enable battery limit at X%" based on the user's selection.
Persistence: The selected charge limit is saved using electron-store and persists across app restarts.
Live Updates: Changing the limit while the limiter is active immediately restarts the background maintenance process at the new level.