### PR TITLE
Fix security issues, simplify app setup/updates, fix calibrate and some minor issues

### DIFF
--- a/app/modules/battery.js
+++ b/app/modules/battery.js
@@ -165,11 +165,12 @@ const initialize_battery = async () => {
         if( development ) log( `Dev mode on, skip updates: ${ skipupdate }` )
 
         // Check for network
-        const online = await Promise.race( [
-            exec_async( `${ path_fix } curl -I https://icanhazip.com &> /dev/null` ).then( () => true ).catch( () => false ),
-            exec_async( `${ path_fix } curl -I https://github.com &> /dev/null` ).then( () => true ).catch( () => false )
-        ] )
-        log( `Internet online: ${ online }` )
+        const online_check_timeout_millisec = 3000
+        const online = await Promise.any( [
+            exec_async( `${ path_fix } curl -I https://icanhazip.com  > /dev/null 2>&1`, online_check_timeout_millisec ),
+            exec_async( `${ path_fix } curl -I https://github.com  > /dev/null 2>&1`, online_check_timeout_millisec )
+        ] ).then( () => true ).catch( () => false )
+        log( `Internet online: `, online)
 
         // Check if battery background executables are installed and owned by root.
         const [

--- a/app/modules/battery.js
+++ b/app/modules/battery.js
@@ -133,7 +133,7 @@ const enable_battery_limiter = async () => {
     try {
         const status = await get_battery_status()
         const allow_force_discharge = get_force_discharge_setting()
-        // 'batery maintain' creates a child process, so when the command exits exec_async does not return.
+        // 'battery maintain' creates a child process, so when the command exits exec_async does not return.
         // That's why here we use a timeout and wait for some time.
         await exec_async(
             `${ battery } maintain ${ status?.maintain_percentage || 80 }${ allow_force_discharge ? ' --force-discharge' : '' }`,

--- a/app/modules/helpers.js
+++ b/app/modules/helpers.js
@@ -1,5 +1,7 @@
 const { promises: fs } = require( 'fs' )
 const { HOME } = process.env
+const util = require("util");
+
 let has_alerted_user_no_home = false
 
 const { dialog } = require( 'electron' )
@@ -21,7 +23,8 @@ const log = async ( ...messages ) => {
     try {
         if( HOME ) {
             await fs.mkdir( `${ HOME }/.battery/`, { recursive: true } )
-            await fs.appendFile( `${ HOME }/.battery/gui.log`, `${ messages.join( '\n' ) }\n`, 'utf8' )
+            const line = util.format(...messages) + "\n";
+            await fs.appendFile( `${ HOME }/.battery/gui.log`, line, 'utf8' )
         } else if( !has_alerted_user_no_home ) {
             alert( `No HOME variable set, this should never happen` )
             has_alerted_user_no_home = true

--- a/app/modules/helpers.js
+++ b/app/modules/helpers.js
@@ -1,6 +1,6 @@
 const { promises: fs } = require( 'fs' )
 const { HOME } = process.env
-const util = require("util");
+const util = require( 'util' )
 
 let has_alerted_user_no_home = false
 

--- a/app/modules/interface.js
+++ b/app/modules/interface.js
@@ -177,7 +177,7 @@ const refresh_logo = async ( percent=80, force ) => {
 // /////////////////////////////*/
 async function set_initial_interface() {
 
-    log( "Starting tray app" )
+    log('\n===\n=== Starting tray app\n===\n')
     tray = new Tray( get_logo_template( 100, true ) )
 
     // Set "loading" context

--- a/battery.sh
+++ b/battery.sh
@@ -761,6 +761,8 @@ if [[ "$action" == "charge" ]]; then
 			caffeinate -is sleep 60
 		fi
 
+		battery_percentage=$(get_battery_percentage)
+
 	done
 
 	disable_charging

--- a/battery.sh
+++ b/battery.sh
@@ -670,9 +670,9 @@ fi
 # Update helper for Terminal users
 if [[ "$action" == "update" ]]; then
 
-	# Temporarily support the 'silent' setting for backward compatibility with older UI versions.
+	# The older GUI versions 1_3_2 and below can not run silent passwordless update and
+	# will complain with alert. Just exit with success and let them update themselves.
 	if [[ "$setting" == "silent" ]]; then
-		sudo -n $battery_binary update_silent
 		exit 0
 	fi
 

--- a/battery.sh
+++ b/battery.sh
@@ -727,9 +727,9 @@ if [[ "$action" == "adapter" ]]; then
 
 	# Set charging to on and off
 	if [[ "$setting" == "on" ]]; then
-		enable_discharging
-	elif [[ "$setting" == "off" ]]; then
 		disable_discharging
+	elif [[ "$setting" == "off" ]]; then
+		enable_discharging
 	else
 		log "Error: $setting is not \"on\" or \"off\"."
 		exit 1

--- a/battery.sh
+++ b/battery.sh
@@ -6,8 +6,10 @@
 ## ###############
 BATTERY_CLI_VERSION="v1.3.2"
 
-# Path fixes for unexpected environments
-PATH=/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
+# If a script may run as root:
+#   - Reset PATH to safe defaults at the very beginning of the script.
+#   - Never include user-owned directories in PATH.
+PATH=/usr/bin:/bin:/usr/sbin:/sbin
 
 ## ###############
 ## Variables

--- a/battery.sh
+++ b/battery.sh
@@ -169,7 +169,7 @@ subsetting=$3
 ## ###############
 
 function log() {
-	echo -e "$(date +%D-%T) - $1"
+	echo -e "$(date +%D-%T) [$$]: $*"
 }
 
 function valid_percentage() {

--- a/battery.sh
+++ b/battery.sh
@@ -229,16 +229,9 @@ function log_smc_capabilities() {
 # Change magsafe color
 # see community sleuthing: https://github.com/actuallymentor/battery/issues/71
 function change_magsafe_led_color() {
-	log "MagSafe LED function invoked"
-	color=$1
+	local color=$1
 
-	# Check whether user can run color changes without password (required for backwards compatibility)
-	if sudo -n smc -k ACLC -r &>/dev/null; then
-		log "💡 Setting magsafe color to $color"
-	else
-		log "🚨 Your version of battery is using an old visudo file, please run 'battery visudo' to fix this, until you do battery cannot change magsafe led colors"
-		return
-	fi
+	log "💡 Setting magsafe color to $color"
 
 	if [[ "$color" == "green" ]]; then
 		log "setting LED to green"

--- a/battery.sh
+++ b/battery.sh
@@ -550,8 +550,14 @@ if [[ $EUID -eq 0 ]]; then
 	fi
 fi
 
+# Version message
+if [[ "$action" == "version" ]] || [[ "$action" == "--version" ]]; then
+	echo "$BATTERY_CLI_VERSION"
+	exit 0
+fi
+
 # Help message
-if [ -z "$action" ] || [[ "$action" == "help" ]]; then
+if [ -z "$action" ] || [[ "$action" == "help" ]] || [[ "$action" == "--help" ]]; then
 	echo -e "$helpmessage"
 	exit 0
 fi

--- a/battery.sh
+++ b/battery.sh
@@ -534,6 +534,9 @@ function fixup_installation_owner_mode() {
 }
 
 function is_latest_version_installed() {
+	# Check if content is reachable first with HEAD request
+	curl -sSI "$github_url_battery_sh" &>/dev/null || return 0
+	# Start downloading and check version
 	curl -sS "$github_url_battery_sh" 2>/dev/null | grep -q "$BATTERY_CLI_VERSION"
 }
 

--- a/battery.sh
+++ b/battery.sh
@@ -450,6 +450,9 @@ if [[ "$action" == "visudo" ]]; then
 			sudo chmod 440 $visudo_file
 		fi
 
+		# Delete tempfile
+		rm $visudo_tmpfile
+
 		# exit because no changes are needed
 		exit 0
 

--- a/setup.sh
+++ b/setup.sh
@@ -77,7 +77,8 @@ unzip -qq $batteryfolder/repo.zip -d $batteryfolder
 cp -r $batteryfolder/$in_zip_folder_name/* $batteryfolder
 rm $batteryfolder/repo.zip
 
-echo "[  4 ] Make sure $binfolder exists and owned by root"
+echo "[  4 ] Make sure $binfolder is recreated and owned by root"
+sudo rm -rf "$binfolder" # start with an empty $binfolder and ensure there is no symlink or file at the path
 sudo install -d -m 755 -o root -g wheel "$binfolder"
 
 echo "[  5 ] Install prebuilt smc binary into $binfolder"

--- a/setup.sh
+++ b/setup.sh
@@ -91,35 +91,35 @@ echo "[  7 ] Make sure the PATH environment variable includes '$binfolder'"
 if ! grep -qF "$binfolder" $path_configfile 2>/dev/null; then
 	printf '%s\n' "$binfolder" | sudo tee "$path_configfile" >/dev/null
 fi
-sudo chown root:wheel $path_configfile
-sudo chmod 644 $path_configfile
+sudo chown -h root:wheel $path_configfile
+sudo chmod -h 644 $path_configfile
 # Create a symlink for rare shells that do not initialize PATH from /etc/paths.d (including the current one)
 sudo mkdir -p /usr/local/bin
 sudo ln -sf "$binfolder/battery" /usr/local/bin/battery
-sudo chown root:wheel /usr/local/bin/battery
+sudo chown -h root:wheel /usr/local/bin/battery
 # Create a link to smc as well to silence older GUI apps running with updated background executables
 # (consider removing in the next releases)
 sudo ln -sf "$binfolder/smc" /usr/local/bin/smc
-sudo chown root:wheel /usr/local/bin/smc
+sudo chown -h root:wheel /usr/local/bin/smc
 
 echo "[  8 ] Set ownership and permissions for $configfolder"
 mkdir -p $configfolder
-sudo chown -R $calling_user $configfolder
-sudo chmod 755 $configfolder
+sudo chown -hRP $calling_user $configfolder
+sudo chmod -h 755 $configfolder
 
 touch $logfile
-sudo chown $calling_user $logfile
-sudo chmod 644 $logfile
+sudo chown -h $calling_user $logfile
+sudo chmod -h 644 $logfile
 
 touch $pidfile
-sudo chown $calling_user $pidfile
-sudo chmod 644 $pidfile
+sudo chown -h $calling_user $pidfile
+sudo chmod -h 644 $pidfile
 
 # Fix permissions for 'create_daemon' action
 echo "[  9 ] Fix ownership and permissions for $(dirname "$launch_agent_plist")"
-sudo chown $calling_user "$(dirname "$launch_agent_plist")"
-sudo chmod 755 "$(dirname "$launch_agent_plist")"
-sudo chown -f $calling_user "$launch_agent_plist" 2>/dev/null
+sudo chown -h $calling_user "$(dirname "$launch_agent_plist")"
+sudo chmod -h 755 "$(dirname "$launch_agent_plist")"
+sudo chown -hf $calling_user "$launch_agent_plist" 2>/dev/null
 
 echo "[ 10 ] Setup visudo configuration"
 sudo $binfolder/battery visudo

--- a/setup.sh
+++ b/setup.sh
@@ -1,30 +1,63 @@
 #!/bin/bash
 
+#
+# ‼️ SECURITY NOTES FOR MAINTAINERS:
+#
+# This app uses a visudo configuration that allows a background script running as
+# an unprivileged user to execute battery management commands without requiring a
+# user password. This requires careful installation and design to avoid potential
+# privilege-escalation vulnerabilities.
+#
+# Rule of thumb:
+# - Unprivileged users must not be able to modify, replace, or inject any code
+#   that can be executed with root privileges.
+#
+# For this reason:
+# - All battery-related binaries and scripts that are executed via sudo,
+#   including those that prompt for a user password, must be owned by root.
+# - They must not be writable by group or others.
+# - Their parent directories must also be owned by root and not be writable by
+#   unprivileged users, to prevent the replacement of executables.
+#
+
 # User welcome message
 echo -e "\n####################################################################"
 echo '# 👋 Welcome, this is the setup script for the battery CLI tool.'
-echo -e "# Note: this script will ask for your password once or multiple times."
+echo -e "# Note: this script may ask for your password."
 echo -e "####################################################################\n\n"
 
-# Set environment variables
-tempfolder=~/.battery-tmp
-binfolder=/usr/local/bin
-mkdir -p $tempfolder
+# Determine unprivileged user name
+if [[ -n "$1" ]]; then
+	calling_user="$1"
+else
+	if [[ -n "$SUDO_USER" ]]; then
+		calling_user=$SUDO_USER
+	else
+		calling_user=$USER
+	fi
+fi
+if [[ "$calling_user" == "root" ]]; then
+	echo "❌ Failed to determine unprivileged username"
+	exit 1
+fi
 
-# Set script value
-calling_user=${1:-"$USER"}
+# Set variables
+tempfolder=/Users/$calling_user/.battery-tmp
+binfolder=/usr/local/bin
 configfolder=/Users/$calling_user/.battery
 pidfile=$configfolder/battery.pid
 logfile=$configfolder/battery.log
+launch_agent_plist=/Users/$calling_user/Library/LaunchAgents/battery.plist
 
 # Ask for sudo once, in most systems this will cache the permissions for a bit
 sudo echo "🔋 Starting battery installation"
-echo -e "[ 1 ] Superuser permissions acquired."
+echo "[ 1 ] Superuser permissions acquired."
 
 # Note: github names zips by <reponame>-<branchname>.replace( '/', '-' )
 update_branch="main"
 in_zip_folder_name="battery-$update_branch"
 batteryfolder="$tempfolder/battery"
+
 echo "[ 2 ] Downloading latest version of battery CLI"
 rm -rf $batteryfolder
 mkdir -p $batteryfolder
@@ -33,44 +66,41 @@ unzip -qq $batteryfolder/repo.zip -d $batteryfolder
 cp -r $batteryfolder/$in_zip_folder_name/* $batteryfolder
 rm $batteryfolder/repo.zip
 
-# Move built file to bin folder
-echo "[ 3 ] Move smc to executable folder"
-sudo mkdir -p $binfolder
-sudo cp $batteryfolder/dist/smc $binfolder
-sudo chown $calling_user $binfolder/smc
-sudo chmod 755 $binfolder/smc
-sudo chmod +x $binfolder/smc
+echo "[ 3 ] Make sure $binfolder exists and owned by root"
+sudo install -d -m 755 -o root -g wheel "$binfolder"
 
-echo "[ 4 ] Writing script to $binfolder/battery for user $calling_user"
-sudo cp $batteryfolder/battery.sh $binfolder/battery
+echo "[ 4 ] Install prebuilt smc binary into $binfolder"
+sudo install -m 755 -o root -g wheel "$batteryfolder/dist/smc" "$binfolder/smc"
 
-echo "[ 5 ] Setting correct file permissions for $calling_user"
-# Set permissions for battery executables
-sudo chown -R $calling_user $binfolder/battery
-sudo chmod 755 $binfolder/battery
-sudo chmod +x $binfolder/battery
+echo "[ 5 ] Install battery script into $binfolder"
+sudo install -m 755 -o root -g wheel "$batteryfolder/battery.sh" "$binfolder/battery"
 
-# Set permissions for logfiles
+echo "[ 6 ] Set ownership and permissions for $configfolder"
 mkdir -p $configfolder
 sudo chown -R $calling_user $configfolder
+sudo chmod 755 $configfolder
 
 touch $logfile
 sudo chown $calling_user $logfile
-sudo chmod 755 $logfile
+sudo chmod 644 $logfile
 
 touch $pidfile
 sudo chown $calling_user $pidfile
-sudo chmod 755 $pidfile
+sudo chmod 644 $pidfile
 
-sudo chown $calling_user $binfolder/battery
+# Fix permissions for 'create_daemon' action
+echo "[ 7 ] Fix ownership and permissions for $(dirname "$launch_agent_plist")"
+sudo chown $calling_user "$(dirname "$launch_agent_plist")"
+sudo chmod 755 "$(dirname "$launch_agent_plist")"
+sudo chown -f $calling_user "$launch_agent_plist"
 
-echo "[ 6 ] Setting up visudo declarations"
-sudo $batteryfolder/battery.sh visudo $USER
+echo "[ 8 ] Setup visudo configuration"
+sudo $binfolder/battery visudo $calling_user
 sudo chown -R $calling_user $configfolder
 
 # Remove tempfiles
-cd ../..
-echo "[ 7 ] Removing temp folder $tempfolder"
+echo "[ 9 ] Remove temp folder $tempfolder"
 rm -rf $tempfolder
 
 echo -e "\n🎉 Battery tool installed. Type \"battery help\" for instructions.\n"
+exit 0

--- a/setup.sh
+++ b/setup.sh
@@ -95,7 +95,7 @@ sudo chmod 755 "$(dirname "$launch_agent_plist")"
 sudo chown -f $calling_user "$launch_agent_plist"
 
 echo "[ 8 ] Setup visudo configuration"
-sudo $binfolder/battery visudo $calling_user
+sudo $binfolder/battery visudo
 sudo chown -R $calling_user $configfolder
 
 # Remove tempfiles

--- a/update.sh
+++ b/update.sh
@@ -2,30 +2,65 @@
 
 echo -e "🔋 Starting battery update\n"
 
+# This script is running as root:
+#   - Reset PATH to safe defaults at the very beginning of the script.
+#   - Never include user-owned directories in PATH.
+PATH=/usr/bin:/bin:/usr/sbin:/sbin
+
+# Define the installation directory for the battery background executables
+binfolder="/usr/local/co.palokaj.battery"
+
+function is_launched_by_gui_app() {
+	# Determine the process group ID (PGID) of the current process
+	local this_process_pgid="$(ps -o pgid= -p $$ | tr -d ' ')"
+	# Return 0 if any process in the same process group has battery.app or Electron.app in its command string
+	ps -x -g $this_process_pgid -o command= -ww 2>/dev/null | grep -qE '(battery\.app|Electron\.app)' >&/dev/null
+}
+
+# If running as an unprivileged user and launched by GUI app
+if [[ $EUID -ne 0 ]] && is_launched_by_gui_app; then
+	# This execution path is taken when GUI app version 1_3_2 or earlier launches update using
+	# the battery script of the same version. This is expected when a new version of battery.sh
+	# is released but the GUI app has not been updated yet.
+	# Exit successfully with a silent warning to avoid disrupting the existing installation.
+	printf "%s\n%s\n" \
+		"The update to the next version requires root privileges." \
+		"Run the updated menu bar GUI app or issue the 'battery update' command in Terminal."
+	exit 0
+fi
+
+# Trigger reinstall for Terminal users to update from version 1_3_2 or earlier.
+# Consider removing the following if..fi block in future versions when you believe
+# that users are no longer using versions 1_3_2 or earlier. New versions of battery.sh are using
+# more comprehensive checks in 'battery update' in order to trigger 'battery reinstall' when needed.
+if [[ $EUID -ne 0 && ! -x "$binfolder/battery" ]]; then
+	echo -e "💡 This battery update requires a full reinstall...\n"
+	curl -sS "https://raw.githubusercontent.com/actuallymentor/battery/main/setup.sh" | bash
+	$binfolder/battery maintain recover
+	exit 0
+fi
+
 echo -n "[ 1 ] Allocating temp folder: "
 tempfolder="$(mktemp -d)"
 echo "$tempfolder"
-function cleanup() {
-	echo "[ 4 ] Removed temporary folder"
-	rm -rf "$tempfolder";
-}
+function cleanup() { rm -rf "$tempfolder"; }
 trap cleanup EXIT
 
-binfolder=/usr/local/bin
 updatefolder="$tempfolder/battery"
 mkdir -p $updatefolder
 
-echo "[ 2 ] Downloading latest battery version"
-mkdir -p $updatefolder
-if curl -sS -o $updatefolder/battery.sh https://raw.githubusercontent.com/actuallymentor/battery/main/battery.sh; then
-	echo "[ 3 ] Writing script to $binfolder/battery"
-	set -eu
-	sudo install -d -m 755 -o root -g wheel "$binfolder"
-	sudo install -m 755 -o root -g wheel "$updatefolder/battery.sh" "$binfolder/battery"
-	sudo chown root:wheel "$binfolder/smc"
-	echo -e "\n🎉 Battery tool updated.\n"
-else
+echo "[ 2 ] Downloading the latest battery version"
+if ! curl -sS -o $updatefolder/battery.sh https://raw.githubusercontent.com/actuallymentor/battery/main/battery.sh; then
 	err=$?
 	echo -e "\n❌ Failed to download the update.\n"
 	exit $err
 fi
+
+echo "[ 3 ] Writing script to $binfolder/battery"
+sudo install -d -m 755 -o root -g wheel "$binfolder"
+sudo install -m 755 -o root -g wheel "$updatefolder/battery.sh" "$binfolder/battery"
+
+echo "[ 4 ] Remove temporary folder"
+rm -rf "$tempfolder";
+
+echo -e "\n🎉 Battery tool updated.\n"


### PR DESCRIPTION
Primary goal of this PR is to fix the #443 .

All changes in bash scripts and GUI (including updates from current version 1.3.2 using GUI and Terminal) were tested on Sequoia 15.7.3 and Tahoe 26.2 (which is the latest).

During the update GUI users will be asked to reinstall background executables. Terminal users can just run `battery update` as usual. In both cases user password will be required.

---

First of all let me start with assuring you that this PR is not vibe-coded. Every change I made have a reason, I'm aware of each modification and understand what they do. Now, let’s look at the changes from a bird’s-eye perspective

### Security improvements
Battery limiter requires root previleges to set the values of SMC keys which control macbook charging. That means that maintainers have to pay a special attention to app security, specifically to privilage escalation attacks. This PR addresses the following attack scenarios:
- Modification of battery executables: A user might run some third-party app they trust; this app never asks for a user password, but if it can modify executables that run as root (or legitimately ask for the user password), an attacker can get their code executed with root privileges. To address this problem, this PR makes the battery background executables owned by root and writable by root only. Only root can change file/folder ownership on Unix systems, so any third-party app running as the user loses the ability to modify the battery executables.
- Replacement of battery executables: Essentially the same as modification. Even if the file itself is owned by root, if the parent directory is owned by the user, the user can remove the file and create a new one. To prevent this, this PR ensures that the /usr/local/bin directory is also owned by root. macOS protects grandparent directories by other means, but does not do the same for /usr/local/bin (at least on Sequoia).
- PATH-based spoofing: By modifying the PATH variable, an attacker can get their own battery executed and trick a user into entering a password. The battery.sh script already resets the PATH variable to hardcoded safe defaults right after launch, diminishing the problem to almost non-existent. This PR additionally hardcodes the full paths to the battery executables in our scripts, which can be useful when we consider app maintenance in the long run.
- GitHub URLs protection: Those are already hardcoded and safe. This PR just adds comments for maintainers about the importance of keeping URLs hardcoded. I almost made that mistake myself.

### Setup/Update functionality in battery.sh
Since the battery background executables are not writable by the user, root privileges are required for updates. To keep updates silent on each startup of the GUI app, this PR adds a passwordless 'update_silent' action to the battery.sh script (via visudo config, same way as we already do for smc). This same action is also used by the 'battery update' action, so updates from the Terminal are also passwordless. Normally, with this PR, a user will have to enter a password twice: during installation of the background binaries and during uninstall.
Users no longer need to use the `battery visudo` action, even though I suspect few of them ever did. The `update_silent` action executes battery visudo after each update. Even if no updates are available, `update_silent` still invokes `battery visudo` and ensures that the ownership and permissions of the battery files are intact. The `visudo` action does not overwrite sudoers config on every invocation. It writes it only if it is missing or outdated, so it is OK to invoke it on each update.
In the past some users had an issues related to the ownership of battery config folder or battery daemon plist, because they invoked `battery visudo` or other actions with sudo. I did it many times myself. With this PR the `visudo` action uses system allocated cache folder to store its temp file and not touching config folder at all. Additionally, the PR adds some guards to make sure some actions are not executed with sudo by mistake.

### Setup/Update functionality in app/modules/battery.js

This functionality is located in `initialize_battery` function. This PR simplifies the process to a simple condition: 
```
if (not_installed) { install } 
else { try updating using passwordless 'sudo battery update_silent' }
```
The decision about whether to install or update is based on:
- availability of executables
- ownership of executables and their parrent folder
- is passwordless update_silent enabled or not (absense of visudo config is assumed otherwise)

If any of the conditions fail, the GUI app triggers reinstallation of background components asking for user password.
Silent update is launched otherwise. 
The time app checks for updates (when user sees the "Updating..." message in menubar) is significantly reduced with this PR comparing to current version 1.3.2, even though I'm not sure why.

### exec_async() and other shell execution helpers in app/modules/battery.js

Existing exec_async related functionality makes it difficult to maintain the app and introduces some bugs:
- If a shell command prints a warning to stderr, exec_async() considers it as an error. As a result, some users had "Error installing battery limiter: undefined" alert due to a syntax error in their '.bashrc'. The output to stderr is not an error indication, apps also using stderr comunicate warnings.
- When an error occurs, both stderr and stdout are lost, even though the app tries to return all of them, only the error arrives. This makes logs less useful and complicates debugging.
- Each and every exec_async() call the app makes has a hidden 2 second timeout. If the shell command does not return during 2 seconds the exec_async() indicates success with 'undefined' value.

With this PR:
- The stderr output is no longer treated as an error.
- Both stdout and stderr are available for exec_async() user after the command completes. Both stdout and stderr are/(can be) logged upon successful execution or when an error occurs.
- The timeouts are enabled only explicitly. In our case, only "battery maintain" needs timeout, because when it succeeds the Electron does not indicate command completion until all child processes quit and file descriptors closed.

### Other changes
- Fix never-ending 'battery charge' action (#439). A line updating loop condition variable were missing.
- Fix online connectivity check in GUI app. The previous implementation let the first completed check determine the "online" status, so it could report offline even if one URL was reachable. With this PR, "online" is true if either of the two URLs is reachable, and false otherwise.
- Add `--help` and `--version` actions (#433). Because they are trivial to implement, and it’s sometimes annoying to run battery help with its long output and scroll back  just to find out which version is installed.
- Fix confusing on/off meaning in `adapter` action. Before the fix, `battery adapter on` would actually disable the adapter.
- Add PID to battery.sh log messages. Because it's useful to see if log messages belong to the same process or different ones.
- battery.sh: Check network reachability before the version check. Before the fix, battery update would say that a new version is available when the internet is offline (it would fail later, of course). Now it just says “☑️ No updates found”. Honestly, now I’m not sure about this one. It seems confusing either way.
- Consistent behavior for charge/discharge actions. Both actions start charging/discharging and run a loop until the requested charge level is reached. Previously, `battery charge` killed the maintenance process, while `battery discharge` did not (otherwise maintenance process would kill itself with --force-discharge option). With this PR, both "charge" and "discharge" actions kill maintenance process, but only when they are called by user from Terminal. This prevents interference between the two charge-controlling tasks. These actions wouldn't work otherwise. Additionally, since they stop maintenance, both actions now restore it on completion, again only when run directly from the Terminal. This change is implemented using environment variable flag, so affected clients (if any) can easily adapt to the new behavior.
- Fix `calibrate` action. It was severely broken and was trying to run calibration in a background process for no reason. With this PR, it runs in a Terminal window. Similar to the charge/discharge actions, it terminates the maintenance process and restores it upon completion. The opposite is true as well: if the user launches maintenance in the Terminal or by starting the GUI menubar app, the calibration process is terminated. We would need to implement some kind of confirmations one day. Tested it once and now coconutBattery reports that battery health increased by 2%. Maybe it was worth it.
