### PR TITLE
Add tray popup for custom charge limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ The first time you open the app, it will ask for your administator password so i
 - Enables charging when your battery is under 80% charged
 - Keeps the limit engaged even after rebooting
 - Keeps the limit engaged even after closing the tray app
-- Also automatically installs the `battery` command line tool. If you want a custom charging percentage, the CLI is the only way to do that.
+- Also automatically installs the `battery` command line tool. If you want a custom charging percentage, you can use the CLI or the tray popup.
+- The tray app also includes an `Adjust charging limits…` popup with sliders for ceiling-only or floor-and-ceiling charging.
 
 Do you have questions, comments, or feature requests? [Open an issue here](https://github.com/actuallymentor/battery/issues) or [Tweet at me](https://twitter.com/actuallymentor).
 

--- a/app/modules/battery.js
+++ b/app/modules/battery.js
@@ -2,7 +2,7 @@
 const { app } = require( 'electron' )
 const { exec } = require( 'node:child_process' )
 const { log, alert, wait, confirm } = require( './helpers' )
-const { get_force_discharge_setting } = require( './settings' )
+const { get_force_discharge_setting, get_maintenance_command } = require( './settings' )
 const { USER } = process.env
 const binfolder = '/usr/local/co.palokaj.battery'
 const battery = `${ binfolder }/battery`
@@ -133,10 +133,11 @@ const enable_battery_limiter = async () => {
     try {
         const status = await get_battery_status()
         const allow_force_discharge = get_force_discharge_setting()
+        const maintenance_command = get_maintenance_command()
         // 'battery maintain' creates a child process, so when the command exits exec_async does not return.
         // That's why here we use a timeout and wait for some time.
         await exec_async(
-            `${ battery } maintain ${ status?.maintain_percentage || 80 }${ allow_force_discharge ? ' --force-discharge' : '' }`,
+            `${ battery } ${ maintenance_command }${ allow_force_discharge ? ' --force-discharge' : '' }`,
             1000    // timeout in milliseconds
         ).catch( e => {
             if ( e.code !== 'ETIMEDOUT' ) throw e;

--- a/app/modules/interface.js
+++ b/app/modules/interface.js
@@ -2,7 +2,8 @@ const { shell, app, Tray, Menu, powerMonitor, nativeTheme } = require( 'electron
 const { enable_battery_limiter, disable_battery_limiter, initialize_battery, is_limiter_enabled, get_battery_status, uninstall_battery } = require( './battery' )
 const { log } = require( "./helpers" )
 const { get_logo_template } = require( './theme' )
-const { get_force_discharge_setting, update_force_discharge_setting } = require( './settings' )
+const { get_force_discharge_setting, update_force_discharge_setting, get_maintenance_settings } = require( './settings' )
+const { open_limits_window } = require( './limits_window' )
 
 /* ///////////////////////////////
 // Menu helpers
@@ -15,13 +16,15 @@ const generate_app_menu = async () => {
 
     try {
         // Get battery and daemon status
-        const { battery_state, daemon_state, maintain_percentage=80, percentage } = await get_battery_status()
+        const { battery_state, daemon_state, percentage } = await get_battery_status()
 
         // Check if limiter is on
         const limiter_on = await is_limiter_enabled()
 
         // Check force discharge setting
         const allow_discharge = get_force_discharge_setting()
+        const { floor_enabled, floor_percentage, ceiling_percentage } = get_maintenance_settings()
+        const maintenance_label = floor_enabled ? `${ floor_percentage }-${ ceiling_percentage }` : `${ ceiling_percentage }`
 
         // Set tray icon
         log( `Generate app menu percentage: ${ percentage } (discharge ${ allow_discharge ? 'allowed' : 'disallowed' }, limited ${ limiter_on ? 'on' : 'off' })` )
@@ -31,13 +34,17 @@ const generate_app_menu = async () => {
         return Menu.buildFromTemplate( [
 
             {
-                label: `Enable ${ maintain_percentage }% battery limit`,
+                label: `Adjust charging limits…`,
+                click: () => open_limits_window( tray )
+            },
+            {
+                label: `Enable ${ maintenance_label }% battery limit`,
                 type: 'radio',
                 checked: limiter_on,
                 click: enable_limiter
             },
             {
-                label: `Disable ${ maintain_percentage }% battery limit`,
+                label: `Disable ${ maintenance_label }% battery limit`,
                 type: 'radio',
                 checked: !limiter_on,
                 click: disable_limiter

--- a/app/modules/limits_window.js
+++ b/app/modules/limits_window.js
@@ -1,0 +1,108 @@
+const path = require( 'path' )
+const { BrowserWindow, ipcMain, screen } = require( 'electron' )
+const { log } = require( './helpers' )
+const { get_maintenance_settings, set_maintenance_settings } = require( './settings' )
+
+let limits_window = null
+let apply_listener = null
+let close_listener = null
+
+const clamp = ( value, min, max ) => Math.max( min, Math.min( max, value ) )
+
+const position_window = tray => {
+    if( !tray || !limits_window ) return
+
+    const tray_bounds = tray.getBounds()
+    const window_bounds = limits_window.getBounds()
+    const display = screen.getDisplayNearestPoint( {
+        x: tray_bounds.x,
+        y: tray_bounds.y
+    } )
+
+    const x = clamp(
+        Math.round( tray_bounds.x + tray_bounds.width / 2 - window_bounds.width / 2 ),
+        display.workArea.x + 8,
+        display.workArea.x + display.workArea.width - window_bounds.width - 8
+    )
+
+    const y = clamp(
+        Math.round( tray_bounds.y + tray_bounds.height + 8 ),
+        display.workArea.y + 8,
+        display.workArea.y + display.workArea.height - window_bounds.height - 8
+    )
+
+    limits_window.setPosition( x, y, false )
+}
+
+const cleanup_listeners = () => {
+    if( apply_listener ) ipcMain.removeListener( 'battery-limits:apply', apply_listener )
+    if( close_listener ) ipcMain.removeListener( 'battery-limits:close', close_listener )
+    apply_listener = null
+    close_listener = null
+}
+
+const open_limits_window = tray => {
+    if( limits_window ) {
+        limits_window.show()
+        limits_window.focus()
+        position_window( tray )
+        return limits_window
+    }
+
+    limits_window = new BrowserWindow( {
+        width: 360,
+        height: 360,
+        show: false,
+        resizable: false,
+        minimizable: false,
+        maximizable: false,
+        fullscreenable: false,
+        skipTaskbar: true,
+        alwaysOnTop: true,
+        title: 'Battery Optimizer',
+        backgroundColor: '#0f172a',
+        webPreferences: {
+            nodeIntegration: true,
+            contextIsolation: false
+        }
+    } )
+
+    limits_window.removeMenu()
+    limits_window.loadFile( path.join( __dirname, '..', 'views', 'limits.html' ) )
+
+    limits_window.once( 'ready-to-show', () => {
+        if( !limits_window ) return
+        limits_window.show()
+        limits_window.focus()
+        position_window( tray )
+        limits_window.webContents.send( 'battery-limits:init', get_maintenance_settings() )
+    } )
+
+    apply_listener = ( event, settings ) => {
+        if( !limits_window || event.sender.id !== limits_window.webContents.id ) return
+
+        const updated_settings = set_maintenance_settings( settings )
+        log( `Applied battery limits: ${ JSON.stringify( updated_settings ) }` )
+        limits_window.webContents.send( 'battery-limits:applied', updated_settings )
+        limits_window.close()
+    }
+
+    close_listener = ( event ) => {
+        if( !limits_window || event.sender.id !== limits_window.webContents.id ) return
+        limits_window.close()
+    }
+
+    ipcMain.on( 'battery-limits:apply', apply_listener )
+    ipcMain.on( 'battery-limits:close', close_listener )
+
+    limits_window.on( 'closed', () => {
+        cleanup_listeners()
+        limits_window = null
+    } )
+
+    return limits_window
+}
+
+module.exports = {
+    open_limits_window
+}

--- a/app/modules/settings.js
+++ b/app/modules/settings.js
@@ -1,8 +1,31 @@
 const Store = require( 'electron-store' )
 const { log, confirm } = require( './helpers' )
+
+const DEFAULT_FLOOR_PERCENTAGE = 50
+const DEFAULT_CEILING_PERCENTAGE = 80
+
+const clamp_percentage = value => Math.max( 1, Math.min( 100, value ) )
+const normalize_percentage = ( value, fallback ) => {
+    const parsed = Number( value )
+    if( !Number.isFinite( parsed ) ) return fallback
+    return clamp_percentage( Math.round( parsed ) )
+}
+
 const store = new Store( {
     force_discharge_if_needed: {
         type: 'boolean'
+    },
+    maintain_floor_enabled: {
+        type: 'boolean',
+        default: false
+    },
+    maintain_floor_percentage: {
+        type: 'number',
+        default: DEFAULT_FLOOR_PERCENTAGE
+    },
+    maintain_ceiling_percentage: {
+        type: 'number',
+        default: DEFAULT_CEILING_PERCENTAGE
     }
 } )
 
@@ -17,6 +40,56 @@ const toggle_force_discharge = () => {
     const status = get_force_discharge_setting()
     log( `Setting force discharge to ${ !status }` )
     store.set( 'force_discharge_if_needed', !status )
+}
+
+const get_maintenance_settings = () => {
+    const floor_enabled = store.get( 'maintain_floor_enabled' ) === true
+    const floor_percentage = normalize_percentage(
+        store.get( 'maintain_floor_percentage' ),
+        DEFAULT_FLOOR_PERCENTAGE
+    )
+    const ceiling_percentage = normalize_percentage(
+        store.get( 'maintain_ceiling_percentage' ),
+        DEFAULT_CEILING_PERCENTAGE
+    )
+
+    return {
+        floor_enabled,
+        floor_percentage,
+        ceiling_percentage
+    }
+}
+
+const set_maintenance_settings = ( settings = {} ) => {
+    const current_settings = get_maintenance_settings()
+    const next_floor_enabled = typeof settings.floor_enabled === 'boolean'
+        ? settings.floor_enabled
+        : current_settings.floor_enabled
+    const next_floor_percentage = normalize_percentage(
+        settings.floor_percentage,
+        current_settings.floor_percentage
+    )
+    const next_ceiling_percentage = normalize_percentage(
+        settings.ceiling_percentage,
+        current_settings.ceiling_percentage
+    )
+
+    const safe_floor_percentage = Math.min( next_floor_percentage, next_ceiling_percentage - 1 )
+    const safe_ceiling_percentage = Math.max( next_ceiling_percentage, safe_floor_percentage + 1 )
+
+    store.set( 'maintain_floor_enabled', next_floor_enabled )
+    store.set( 'maintain_floor_percentage', next_floor_enabled ? Math.max( 1, safe_floor_percentage ) : next_floor_percentage )
+    store.set( 'maintain_ceiling_percentage', safe_ceiling_percentage )
+
+    const updated_settings = get_maintenance_settings()
+    log( `Updated maintenance settings: ${ JSON.stringify( updated_settings ) }` )
+    return updated_settings
+}
+
+const get_maintenance_command = () => {
+    const { floor_enabled, floor_percentage, ceiling_percentage } = get_maintenance_settings()
+    if( floor_enabled ) return `maintain ${ floor_percentage }-${ ceiling_percentage }`
+    return `maintain ${ ceiling_percentage }`
 }
 
 // Update the force discharge setting
@@ -44,5 +117,8 @@ const update_force_discharge_setting = async () => {
 module.exports = {
     get_force_discharge_setting,
     toggle_force_discharge,
-    update_force_discharge_setting
+    update_force_discharge_setting,
+    get_maintenance_settings,
+    set_maintenance_settings,
+    get_maintenance_command
 }

--- a/app/views/limits.html
+++ b/app/views/limits.html
@@ -1,0 +1,205 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Battery Optimizer</title>
+    <style>
+        :root {
+            color-scheme: dark;
+            --bg: #0f172a;
+            --panel: rgba(15, 23, 42, 0.96);
+            --panel-border: rgba(148, 163, 184, 0.18);
+            --text: #e2e8f0;
+            --muted: #94a3b8;
+            --accent: #38bdf8;
+            --accent-strong: #0ea5e9;
+            --good: #22c55e;
+            --danger: #ef4444;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            min-height: 100vh;
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+            color: var(--text);
+            background:
+                radial-gradient(circle at top left, rgba(56, 189, 248, 0.22), transparent 36%),
+                radial-gradient(circle at bottom right, rgba(34, 197, 94, 0.12), transparent 34%),
+                var(--bg);
+        }
+
+        .card {
+            height: 100vh;
+            padding: 18px 18px 16px;
+            background: var(--panel);
+            border: 1px solid var(--panel-border);
+            border-radius: 18px;
+            box-shadow: 0 18px 40px rgba(2, 6, 23, 0.45);
+            display: flex;
+            flex-direction: column;
+            gap: 16px;
+        }
+
+        .title {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 12px;
+        }
+
+        h1 {
+            margin: 0;
+            font-size: 18px;
+            line-height: 1.1;
+            letter-spacing: -0.02em;
+        }
+
+        .subtitle {
+            margin: 4px 0 0;
+            color: var(--muted);
+            font-size: 12px;
+        }
+
+        .badge {
+            padding: 5px 9px;
+            border-radius: 999px;
+            background: rgba(56, 189, 248, 0.14);
+            border: 1px solid rgba(56, 189, 248, 0.24);
+            color: #bae6fd;
+            font-size: 12px;
+            white-space: nowrap;
+        }
+
+        .section {
+            display: flex;
+            flex-direction: column;
+            gap: 10px;
+            padding: 14px;
+            border-radius: 14px;
+            background: rgba(15, 23, 42, 0.52);
+            border: 1px solid rgba(148, 163, 184, 0.12);
+        }
+
+        .row {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 12px;
+        }
+
+        .label {
+            font-size: 13px;
+            color: var(--text);
+        }
+
+        .value {
+            font-variant-numeric: tabular-nums;
+            color: #cbd5e1;
+            font-size: 13px;
+        }
+
+        input[type="range"] {
+            width: 100%;
+            accent-color: var(--accent);
+        }
+
+        input[type="checkbox"] {
+            width: 16px;
+            height: 16px;
+            accent-color: var(--accent);
+        }
+
+        .checkbox-row {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+        }
+
+        .floor-group[aria-hidden="true"] {
+            display: none;
+        }
+
+        .actions {
+            margin-top: auto;
+            display: flex;
+            justify-content: flex-end;
+            gap: 10px;
+        }
+
+        button {
+            appearance: none;
+            border: 0;
+            border-radius: 10px;
+            padding: 10px 14px;
+            font: inherit;
+            cursor: pointer;
+        }
+
+        .secondary {
+            background: rgba(148, 163, 184, 0.14);
+            color: var(--text);
+        }
+
+        .primary {
+            background: linear-gradient(180deg, var(--accent), var(--accent-strong));
+            color: #052235;
+            font-weight: 600;
+            box-shadow: 0 10px 20px rgba(14, 165, 233, 0.26);
+        }
+
+        .hint {
+            margin: 0;
+            color: var(--muted);
+            font-size: 12px;
+            line-height: 1.4;
+        }
+    </style>
+</head>
+<body>
+    <div class="card">
+        <div class="title">
+            <div>
+                <h1>Battery Optimizer</h1>
+                <p class="subtitle">Adjust the charging ceiling and optional floor from the menu bar.</p>
+            </div>
+            <div class="badge">Menu bar popup</div>
+        </div>
+
+        <div class="section">
+            <div class="checkbox-row">
+                <input id="floor-enabled" type="checkbox" />
+                <label class="label" for="floor-enabled">Enable floor limit</label>
+            </div>
+            <p class="hint">When enabled, charging stops at the ceiling and resumes only after the floor is reached.</p>
+        </div>
+
+        <div class="section floor-group" id="floor-group" aria-hidden="true">
+            <div class="row">
+                <div class="label">Floor</div>
+                <div class="value" id="floor-value">50%</div>
+            </div>
+            <input id="floor" type="range" min="1" max="99" step="1" value="50" />
+        </div>
+
+        <div class="section">
+            <div class="row">
+                <div class="label">Ceiling</div>
+                <div class="value" id="ceiling-value">80%</div>
+            </div>
+            <input id="ceiling" type="range" min="2" max="100" step="1" value="80" />
+        </div>
+
+        <div class="actions">
+            <button class="secondary" id="cancel">Cancel</button>
+            <button class="primary" id="apply">Apply</button>
+        </div>
+    </div>
+
+    <script src="./limits.js"></script>
+</body>
+</html>

--- a/app/views/limits.js
+++ b/app/views/limits.js
@@ -1,0 +1,77 @@
+const { ipcRenderer } = require( 'electron' )
+
+const floorEnabledInput = document.getElementById( 'floor-enabled' )
+const floorGroup = document.getElementById( 'floor-group' )
+const floorInput = document.getElementById( 'floor' )
+const ceilingInput = document.getElementById( 'ceiling' )
+const floorValue = document.getElementById( 'floor-value' )
+const ceilingValue = document.getElementById( 'ceiling-value' )
+const applyButton = document.getElementById( 'apply' )
+const cancelButton = document.getElementById( 'cancel' )
+
+const clamp = ( value, min, max ) => Math.max( min, Math.min( max, value ) )
+
+const renderFloorState = () => {
+    const enabled = floorEnabledInput.checked
+    floorGroup.setAttribute( 'aria-hidden', String( !enabled ) )
+}
+
+const syncLabels = () => {
+    floorValue.textContent = `${ floorInput.value }%`
+    ceilingValue.textContent = `${ ceilingInput.value }%`
+}
+
+const syncBounds = () => {
+    const floor = Number( floorInput.value )
+    const ceiling = Number( ceilingInput.value )
+
+    if( floorEnabledInput.checked ) {
+        if( floor >= ceiling ) {
+            ceilingInput.value = String( clamp( floor + 1, 2, 100 ) )
+        }
+        if( Number( floorInput.value ) >= Number( ceilingInput.value ) ) {
+            floorInput.value = String( clamp( Number( ceilingInput.value ) - 1, 1, 99 ) )
+        }
+    }
+
+    syncLabels()
+}
+
+floorEnabledInput.addEventListener( 'change', () => {
+    renderFloorState()
+    syncBounds()
+} )
+
+floorInput.addEventListener( 'input', syncBounds )
+ceilingInput.addEventListener( 'input', syncBounds )
+
+applyButton.addEventListener( 'click', () => {
+    ipcRenderer.send( 'battery-limits:apply', {
+        floor_enabled: floorEnabledInput.checked,
+        floor_percentage: Number( floorInput.value ),
+        ceiling_percentage: Number( ceilingInput.value )
+    } )
+} )
+
+cancelButton.addEventListener( 'click', () => {
+    ipcRenderer.send( 'battery-limits:close' )
+} )
+
+ipcRenderer.on( 'battery-limits:init', ( _event, settings ) => {
+    floorEnabledInput.checked = settings.floor_enabled === true
+    floorInput.value = String( settings.floor_percentage ?? 50 )
+    ceilingInput.value = String( settings.ceiling_percentage ?? 80 )
+    renderFloorState()
+    syncBounds()
+} )
+
+ipcRenderer.on( 'battery-limits:applied', ( _event, settings ) => {
+    floorEnabledInput.checked = settings.floor_enabled === true
+    floorInput.value = String( settings.floor_percentage )
+    ceilingInput.value = String( settings.ceiling_percentage )
+    renderFloorState()
+    syncBounds()
+} )
+
+renderFloorState()
+syncLabels()


### PR DESCRIPTION
Adds a menu-bar popup with sliders for ceiling-only or floor-and-ceiling charging, persists the chosen values, and wires the Electron tray app to use them when enabling the limiter.\n\nCloses #150.\n\nValidation:\n-  on the modified JS files\n- \n\nNotes:\n- The popup stays in the menu bar app, not the Dock\n- Floor can be disabled for ceiling-only charging